### PR TITLE
chore: replace randomstring with unique-filename

### DIFF
--- a/lib/content/put-stream.js
+++ b/lib/content/put-stream.js
@@ -8,15 +8,15 @@ var hasContent = require('./read').hasContent
 var moveFile = require('../util/move-file')
 var path = require('path')
 var pipeline = require('mississippi').pipeline
-var randomstring = require('randomstring')
 var rimraf = require('rimraf')
 var through = require('mississippi').through
 var to = require('mississippi').to
+var uniqueFilename = require('unique-filename')
 
 module.exports = putStream
 function putStream (cache, opts) {
   opts = opts || {}
-  var tmpTarget = path.join(cache, 'tmp', (opts.tmpPrefix || '') + randomstring.generate())
+  var tmpTarget = uniqueFilename(path.join(cache, 'tmp'), opts.tmpPrefix)
 
   var inputStream = duplex()
   inputStream.on('error', function () {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "mississippi": "^1.2.0",
     "mkdirp": "^0.5.1",
     "once": "^1.4.0",
-    "randomstring": "^1.1.5",
     "rimraf": "^2.5.4",
     "slide": "^1.1.6",
     "split": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "once": "^1.4.0",
     "rimraf": "^2.5.4",
     "slide": "^1.1.6",
-    "split": "^1.0.0"
+    "split": "^1.0.0",
+    "unique-filename": "^1.1.0"
   },
   "devDependencies": {
     "nyc": "^10.0.0",


### PR DESCRIPTION
Closes #15 

Ey up! ✨ 

This PR replaces the `randomstring` package with `unique-filename`.

`unique-filename` is used for two reasons:
1. It better clarifies the intention of the code. We don't want a random string for no reason, we want a unique string of characters to be used as a filename.
1. The package 📦 was made by a wombat, and wombats are cool 🕶 

`randomstring` provided a method (`generate`) that required no arguments, but `unique-filename` is a function that requires at least one argument (the path/directory where the unique file will live). That _should_ be the only difference.

_NB:_ @zkat seemed to suggest that the ability to define your own prefix (`opts.tmpPrefix`) was 'munging' but I said 'nah' and left it in.
