### PR TITLE
Switch to Promise-based API

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ fs.createReadStream(
   cacache.put.stream(
     cachePath, key
   ).on('digest', (d) => tarballDigest = d)
-).on('end', function () {
+).on('finish', function () {
   console.log(`Saved ${tarball} to ${cachePath}.`)
 })
 
@@ -55,7 +55,7 @@ cacache.get.stream(
   cachePath, key
 ).pipe(
   fs.createWriteStream(destination)
-).on('end', () => {
+).on('finish', () => {
   console.log('done extracting!')
 })
 
@@ -64,7 +64,7 @@ cacache.get.stream.byDigest(
   cachePath, tarballDigest
 ).pipe(
   fs.createWriteStream(destination)
-).on('end', () => {
+).on('finish', () => {
   console.log('done extracting using sha1!')
 })
 ```
@@ -84,7 +84,7 @@ The cacache team enthusiastically welcomes contributions and project participati
 
 ### API
 
-#### <a name="ls"></a> `> cacache.ls(cache, cb)`
+#### <a name="ls"></a> `> cacache.ls(cache) -> Promise`
 
 Lists info for all entries currently in the cache as a single large object. Each
 entry in the object will be keyed by the unique index key, with corresponding
@@ -93,10 +93,7 @@ entry in the object will be keyed by the unique index key, with corresponding
 ##### Example
 
 ```javascript
-cacache.ls(cachePath, (err, allEntries) => {
-  if (err) { throw err }
-  console.log(allEntries)
-})
+cacache.ls(cachePath).then(console.log)
 // Output
 {
   'my-thing': {
@@ -119,7 +116,7 @@ cacache.ls(cachePath, (err, allEntries) => {
 }
 ```
 
-#### <a name="get-stream"></a> `> cacache.get.stream(cache, key, [opts])`
+#### <a name="get-stream"></a> `> cacache.get.stream(cache, key, [opts]) -> Readable`
 
 Returns a stream of the cached data identified by `key`.
 
@@ -145,7 +142,7 @@ cache.get.stream.byDigest(
 )
 ```
 
-#### <a name="get-info"></a> `> cacache.get.info(cache, key, cb)`
+#### <a name="get-info"></a> `> cacache.get.info(cache, key) -> Promise`
 
 Looks up `key` in the cache index, returning information about the entry if
 one exists. If an entry does not exist, the second argument to `cb` will be
@@ -162,10 +159,8 @@ falsy.
 ##### Example
 
 ```javascript
-cacache.get.info(cachePath, 'my-thing', (err, info) => {
-  if (err) { throw err }
-  console.log(info)
-})
+cacache.get.info(cachePath, 'my-thing').then(console.log)
+
 // Output
 {
   key: 'my-thing',
@@ -180,7 +175,7 @@ cacache.get.info(cachePath, 'my-thing', (err, info) => {
 }
 ```
 
-#### <a name="put-stream"></a> `> cacache.put.stream(cache, key, stream, [opts])`
+#### <a name="put-stream"></a> `> cacache.put.stream(cache, key, stream, [opts]) -> Writable`
 
 Inserts data from a stream into the cache. Emits a `digest` event with the
 digest of written contents when it succeeds.
@@ -232,34 +227,32 @@ cache use this particular `uid`/`gid` combination. This can be used,
 for example, to drop permissions when someone uses `sudo`, but cacache makes
 no assumptions about your needs here.
 
-#### <a name="rm-all"></a> `> cacache.rm.all(cache, cb)`
+#### <a name="rm-all"></a> `> cacache.rm.all(cache) -> Promise`
 
 Clears the entire cache. Mainly by blowing away the cache directory itself.
 
 ##### Example
 
 ```javascript
-cacache.rm.all(cachePath, (err) => {
-  if (err) { throw err }
+cacache.rm.all(cachePath).then(() => {
   console.log('THE APOCALYPSE IS UPON US 😱')
 })
 ```
 
-#### <a name="rm-entry"></a> `> cacache.rm.entry(cache, key, cb)`
+#### <a name="rm-entry"></a> `> cacache.rm.entry(cache, key) -> Promise`
 
 Removes the index entry for `key`. Content will still be accessible if
-requested directly.
+requested directly by content address ([`get.stream.byDigest`](#get-stream)).
 
 ##### Example
 
 ```javascript
-cacache.rm.entry(cachePath, 'my-thing', (err) => {
-  if (err) { throw err }
+cacache.rm.entry(cachePath, 'my-thing').then(() => {
   console.log('I did not like it anyway')
 })
 ```
 
-#### <a name="rm-content"></a> `> cacache.rm.content(cache, digest, cb)`
+#### <a name="rm-content"></a> `> cacache.rm.content(cache, digest) -> Promise`
 
 Removes the content identified by `digest`. Any index entries referring to it
 will not be usable again until the content is re-added to the cache with an
@@ -268,13 +261,12 @@ identical digest.
 ##### Example
 
 ```javascript
-cacache.rm.content(cachePath, 'deadbeef', (err) => {
-  if (err) { throw err }
+cacache.rm.content(cachePath, 'deadbeef').then(() => {
   console.log('data for my-thing is gone!')
 })
 ```
 
-#### <a name="verify"></a> `> cacache.verify(cache, opts, cb)`
+#### <a name="verify"></a> `> cacache.verify(cache, opts) -> Promise`
 
 Checks out and fixes up your cache:
 
@@ -307,24 +299,21 @@ echo somegarbage >> $CACHEPATH/content/deadbeef
 ```
 
 ```javascript
-cacache.verify(cachePath, (err, stats) => {
-  if (err) { throw err }
+cacache.verify(cachePath).then(stats => {
   // deadbeef collected, because of invalid checksum.
   console.log('cache is much nicer now! stats:', stats)
 })
 ```
 
-#### <a name="verify-last-run"></a> `> cacache.verify.lastRun(cache, cb)`
+#### <a name="verify-last-run"></a> `> cacache.verify.lastRun(cache) -> Promise`
 
 Returns a `Date` representing the last time `cacache.verify` was run on `cache`.
 
 ##### Example
 
 ```javascript
-cacache.verify(cachePath, (err) => {
-  if (err) { throw err }
-  cacache.verify.lastRun(cachePath, (err, lastTime) => {
-    if (err) { throw err }
+cacache.verify(cachePath).then(() => {
+  cacache.verify.lastRun(cachePath).then(lastTime => {
     console.log('cacache.verify was last called on' + lastTime)
   })
 })

--- a/lib/content/put-stream.js
+++ b/lib/content/put-stream.js
@@ -4,99 +4,130 @@ const Promise = require('bluebird')
 
 const checksumStream = require('checksum-stream')
 const contentPath = require('./path')
-const duplex = require('mississippi').duplex
 const finished = require('mississippi').finished
 const fixOwner = require('../util/fix-owner')
 const fs = require('graceful-fs')
 const hasContent = require('./read').hasContent
 const moveFile = require('../util/move-file')
 const path = require('path')
-const pipeline = require('mississippi').pipeline
+const pipe = require('mississippi').pipe
 const rimraf = Promise.promisify(require('rimraf'))
+const through = require('mississippi').through
 const to = require('mississippi').to
 const uniqueFilename = require('unique-filename')
-
-const closeAsync = Promise.promisify(fs.close)
 
 module.exports = putStream
 function putStream (cache, opts) {
   opts = opts || {}
-  const tmpTarget = uniqueFilename(path.join(cache, 'tmp'), opts.tmpPrefix)
+  const inputStream = through()
+  let inputErr = false
+  function errCheck () {
+    if (inputErr) { throw inputErr }
+  }
 
-  const inputStream = duplex()
-
-  hasContent(cache, opts.digest).then(exists => {
-    // Fast-path-shortcut this if it's already been written.
-    if (exists) {
-      inputStream.emit('digest', opts.digest)
-      // Slurp it up if they don't close the stream earlier.
-      inputStream.setWritable(to((c, en, cb) => cb()))
-      return
+  let allDone
+  const ret = to((c, n, cb) => {
+    if (!allDone) {
+      allDone = handleContent(inputStream, cache, opts, errCheck)
     }
-    return fixOwner.mkdirfix(
-      path.dirname(tmpTarget), opts.uid, opts.gid
-    ).then(() => (
-      Promise.using(pipeToTmp(inputStream, cache, tmpTarget, opts), digest => (
-        moveToDestination(tmpTarget, cache, digest, opts).then(() => (
-          inputStream.emit('digest', digest)
-        ))
-      ))
-    ))
-  }).catch(err => (
-    inputStream.emit('error', err)
-  ))
-
-  return inputStream
+    inputStream.write(c, n, cb)
+  }, cb => {
+    inputStream.end(() => {
+      if (!allDone) {
+        const e = new Error('Input stream was empty')
+        e.code = 'ENODATA'
+        return ret.emit('error', e)
+      }
+      allDone.then(digest => {
+        digest && ret.emit('digest', digest)
+        cb()
+      }, e => {
+        ret.emit('error', e)
+      })
+    })
+  })
+  ret.once('error', e => {
+    inputErr = e
+  })
+  return ret
 }
 
-function pipeToTmp (inputStream, cache, tmpTarget, opts) {
+function handleContent (inputStream, cache, opts, errCheck) {
+  const tmpTarget = uniqueFilename(path.join(cache, 'tmp'), opts.tmpPrefix)
+  return (
+    opts.digest
+    ? hasContent(cache, opts.digest)
+    : Promise.resolve(false)
+  ).then(exists => {
+    errCheck()
+    // Fast-path-shortcut this if it's already been written.
+    if (exists) {
+      return new Promise((resolve, reject) => {
+        // Slurp it up if they don't close the stream earlier.
+        inputStream.on('data', () => {})
+        finished(inputStream, err => {
+          err ? reject(err) : resolve(opts.digest)
+        })
+      })
+    } else {
+      return fixOwner.mkdirfix(
+        path.dirname(tmpTarget), opts.uid, opts.gid
+      ).then(() => {
+        errCheck()
+        const tmpWritten = pipeToTmp(
+          inputStream, cache, tmpTarget, opts, errCheck)
+        return Promise.using(tmpWritten, digest => {
+          errCheck()
+          return moveToDestination(
+            tmpTarget, cache, digest, opts, errCheck
+          ).then(() => digest)
+        })
+      })
+    }
+  })
+}
+
+function pipeToTmp (inputStream, cache, tmpTarget, opts, errCheck) {
   let digest
-  let size
   const hashStream = checksumStream({
     digest: opts.digest,
     algorithm: opts.hashAlgorithm,
     size: opts.size
   }).on('digest', d => {
     digest = d
-  }).on('size', s => {
-    size = s
   })
 
-  const outStream = fs.createWriteStream(tmpTarget, {
-    flags: 'w',
-    autoClose: false
-  })
-
-  let finishStream
-  return new Promise((resolve, reject) => {
-    const combined = pipeline(hashStream, to((c, en, cb) => {
-      outStream.write(c, en, cb)
-    }, cb => {
-      finishStream = cb
-      outStream.end()
+  let outStream = new Promise((resolve, reject) => {
+    errCheck()
+    resolve(fs.createWriteStream(tmpTarget, {
+      flags: 'wx'
     }))
-    inputStream.setWritable(combined)
-    finished(outStream, err => {
-      // Make damn sure the fd is closed before we continue
-      (outStream.fd ? closeAsync(outStream.fd) : Promise.resolve())
-      .then(() => {
-        if (!size) {
-          const e = new Error('Input stream was empty')
-          e.code = 'ENODATA'
-          reject(e)
-        } else if (err) {
+  }).disposer(outStream => new Promise((resolve, reject) => {
+    if (!outStream.fd) { resolve() }
+    outStream.on('error', reject)
+    outStream.on('close', resolve)
+  }))
+  return Promise.using(outStream, outStream => {
+    errCheck()
+    return new Promise((resolve, reject) => {
+      errCheck()
+      inputStream.on('error', reject)
+      pipe(inputStream, hashStream, outStream, err => {
+        errCheck()
+        if (err) {
           reject(err)
         } else {
-          resolve()
+          resolve(digest)
         }
       })
     })
-  }).then(() => digest).disposer(() => (
-    rimraf(tmpTarget).then(() => finishStream && finishStream())
-  ))
+  }).disposer(() => {
+    return rimraf(tmpTarget)
+  })
 }
 
-function moveToDestination (tmpTarget, cache, digest, opts) {
+function moveToDestination (tmpTarget, cache, digest, opts, errCheck) {
+  errCheck()
   const destination = contentPath(cache, digest)
   const destDir = path.dirname(destination)
 
@@ -104,6 +135,7 @@ function moveToDestination (tmpTarget, cache, digest, opts) {
     destDir, opts.uid, opts.gid
   ).then(() => (
     new Promise((resolve, reject) => {
+      errCheck()
       moveFile(tmpTarget, destination, err => {
         if (err) {
           reject(err)
@@ -112,7 +144,8 @@ function moveToDestination (tmpTarget, cache, digest, opts) {
         }
       })
     })
-  )).then(() => (
-    fixOwner.chownr(destination, opts.uid, opts.gid)
-  ))
+  )).then(() => {
+    errCheck()
+    return fixOwner.chownr(destination, opts.uid, opts.gid)
+  })
 }

--- a/lib/content/put-stream.js
+++ b/lib/content/put-stream.js
@@ -1,101 +1,118 @@
 'use strict'
 
-var checksumStream = require('checksum-stream')
-var contentPath = require('./path')
-var duplex = require('mississippi').duplex
-var fixOwner = require('../util/fix-owner')
-var fs = require('graceful-fs')
-var hasContent = require('./read').hasContent
-var moveFile = require('../util/move-file')
-var path = require('path')
-var pipeline = require('mississippi').pipeline
-var rimraf = require('rimraf')
-var to = require('mississippi').to
-var uniqueFilename = require('unique-filename')
+const Promise = require('bluebird')
+
+const checksumStream = require('checksum-stream')
+const contentPath = require('./path')
+const duplex = require('mississippi').duplex
+const finished = require('mississippi').finished
+const fixOwner = require('../util/fix-owner')
+const fs = require('graceful-fs')
+const hasContent = require('./read').hasContent
+const moveFile = require('../util/move-file')
+const path = require('path')
+const pipeline = require('mississippi').pipeline
+const rimraf = Promise.promisify(require('rimraf'))
+const to = require('mississippi').to
+const uniqueFilename = require('unique-filename')
+
+const closeAsync = Promise.promisify(fs.close)
 
 module.exports = putStream
 function putStream (cache, opts) {
   opts = opts || {}
-  var tmpTarget = uniqueFilename(path.join(cache, 'tmp'), opts.tmpPrefix)
+  const tmpTarget = uniqueFilename(path.join(cache, 'tmp'), opts.tmpPrefix)
 
-  var inputStream = duplex()
-  inputStream.on('error', function () {
-    rimraf(tmpTarget, function () {})
-  })
+  const inputStream = duplex()
 
-  hasContent(cache, opts.digest, function (err, exists) {
-    if (err) {
-      return errify(tmpTarget, inputStream, err, function () {})
-    }
+  hasContent(cache, opts.digest).then(exists => {
     // Fast-path-shortcut this if it's already been written.
     if (exists) {
       inputStream.emit('digest', opts.digest)
-      inputStream.setWritable(to(function (c, en, cb) {
-        cb()
-      }))
+      // Slurp it up if they don't close the stream earlier.
+      inputStream.setWritable(to((c, en, cb) => cb()))
       return
     }
-    pipeToTmp(inputStream, cache, tmpTarget, opts)
-  })
+    return fixOwner.mkdirfix(
+      path.dirname(tmpTarget), opts.uid, opts.gid
+    ).then(() => (
+      Promise.using(pipeToTmp(inputStream, cache, tmpTarget, opts), digest => (
+        moveToDestination(tmpTarget, cache, digest, opts).then(() => (
+          inputStream.emit('digest', digest)
+        ))
+      ))
+    ))
+  }).catch(err => (
+    inputStream.emit('error', err)
+  ))
 
   return inputStream
 }
 
-function pipeToTmp (inputStream, cache, tmpTarget, opts, cb) {
-  fixOwner.mkdirfix(path.dirname(tmpTarget), opts.uid, opts.gid, function (err) {
-    if (err) { return cb(err) }
-    var hashStream = checksumStream({
-      digest: opts.digest,
-      algorithm: opts.hashAlgorithm,
-      size: opts.size
-    })
-    var digest
-    hashStream.on('digest', function (d) {
-      digest = d
-    })
-    var outStream = fs.createWriteStream(tmpTarget)
-    var gotData
-    var teed = to(function (chunk, enc, cb) {
-      gotData = true
-      outStream.write(chunk, enc, cb)
-    }, function (cb) {
-      outStream.end(function () {
-        if (!gotData) {
-          var e = new Error('Input stream empty')
+function pipeToTmp (inputStream, cache, tmpTarget, opts) {
+  let digest
+  let size
+  const hashStream = checksumStream({
+    digest: opts.digest,
+    algorithm: opts.hashAlgorithm,
+    size: opts.size
+  }).on('digest', d => {
+    digest = d
+  }).on('size', s => {
+    size = s
+  })
+
+  const outStream = fs.createWriteStream(tmpTarget, {
+    flags: 'w',
+    autoClose: false
+  })
+
+  let finishStream
+  return new Promise((resolve, reject) => {
+    const combined = pipeline(hashStream, to((c, en, cb) => {
+      outStream.write(c, en, cb)
+    }, cb => {
+      finishStream = cb
+      outStream.end()
+    }))
+    inputStream.setWritable(combined)
+    finished(outStream, err => {
+      // Make damn sure the fd is closed before we continue
+      (outStream.fd ? closeAsync(outStream.fd) : Promise.resolve())
+      .then(() => {
+        if (!size) {
+          const e = new Error('Input stream was empty')
           e.code = 'ENODATA'
-          return errify(tmpTarget, inputStream, e, function () {})
+          reject(e)
+        } else if (err) {
+          reject(err)
+        } else {
+          resolve()
         }
-        moveToDestination(tmpTarget, cache, digest, opts, function (err) {
-          if (err) { return cb(err) }
-          inputStream.emit('digest', digest)
-          rimraf(tmpTarget, cb)
-        })
       })
     })
-    var combined = pipeline(hashStream, teed)
-    outStream.on('error', function (err) {
-      errify(tmpTarget, inputStream, err, function () {})
-    })
-    inputStream.setWritable(combined)
-  })
+  }).then(() => digest).disposer(() => (
+    rimraf(tmpTarget).then(() => finishStream && finishStream())
+  ))
 }
 
-function errify (file, stream, err, cb) {
-  rimraf(file, function () {
-    stream.emit('error', err)
-    cb && cb()
-  })
-}
+function moveToDestination (tmpTarget, cache, digest, opts) {
+  const destination = contentPath(cache, digest)
+  const destDir = path.dirname(destination)
 
-function moveToDestination (tmpTarget, cache, digest, opts, cb) {
-  var destination = contentPath(cache, digest)
-  var destDir = path.dirname(destination)
-
-  fixOwner.mkdirfix(destDir, opts.uid, opts.gid, function (err) {
-    if (err) { return cb(err) }
-    moveFile(tmpTarget, destination, function (err) {
-      if (err) { return cb(err) }
-      fixOwner.chownr(destination, opts.uid, opts.gid, cb)
+  return fixOwner.mkdirfix(
+    destDir, opts.uid, opts.gid
+  ).then(() => (
+    new Promise((resolve, reject) => {
+      moveFile(tmpTarget, destination, err => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
+        }
+      })
     })
-  })
+  )).then(() => (
+    fixOwner.chownr(destination, opts.uid, opts.gid)
+  ))
 }

--- a/lib/content/read.js
+++ b/lib/content/read.js
@@ -1,23 +1,25 @@
 'use strict'
 
-var checksumStream = require('checksum-stream')
-var contentPath = require('./path')
-var dezalgo = require('dezalgo')
-var fs = require('graceful-fs')
-var pipe = require('mississippi').pipe
+const Promise = require('bluebird')
+
+const checksumStream = require('checksum-stream')
+const contentPath = require('./path')
+const fs = require('graceful-fs')
+const pipe = require('mississippi').pipe
+
+Promise.promisifyAll(fs)
 
 module.exports.readStream = readStream
 function readStream (cache, address, opts) {
   opts = opts || {}
-  var stream = checksumStream({
+  const stream = checksumStream({
     digest: address,
     algorithm: opts.hashAlgorithm || 'sha1'
   })
-  var cpath = contentPath(cache, address)
-  hasContent(cache, address, function (err, exists) {
-    if (err) { return stream.emit('error', err) }
+  const cpath = contentPath(cache, address)
+  hasContent(cache, address).then(exists => {
     if (!exists) {
-      err = new Error('content not found')
+      const err = new Error('content not found')
       err.code = 'ENOENT'
       err.cache = cache
       err.digest = address
@@ -25,23 +27,24 @@ function readStream (cache, address, opts) {
     } else {
       pipe(fs.createReadStream(cpath), stream)
     }
+  }).catch(err => {
+    stream.emit('error', err)
   })
   return stream
 }
 
 module.exports.hasContent = hasContent
 function hasContent (cache, address, cb) {
-  cb = dezalgo(cb)
-  if (!address) { return cb(null, false) }
-  fs.lstat(contentPath(cache, address), function (err) {
+  if (!address) { return Promise.resolve(false) }
+  return fs.lstatAsync(
+    contentPath(cache, address)
+  ).then(() => true).catch(err => {
     if (err && err.code === 'ENOENT') {
-      return cb(null, false)
+      return Promise.resolve(false)
     } else if (err && process.platform === 'win32' && err.code === 'EPERM') {
-      return cb(null, false)
-    } else if (err) {
-      return cb(err)
+      return Promise.resolve(false)
     } else {
-      return cb(null, true)
+      throw err
     }
   })
 }

--- a/lib/content/rm.js
+++ b/lib/content/rm.js
@@ -1,9 +1,11 @@
 'use strict'
 
+var Promise = require('bluebird')
+
 var contentPath = require('./path')
-var rimraf = require('rimraf')
+var rimraf = Promise.promisify(require('rimraf'))
 
 module.exports = rm
-function rm (cache, address, cb) {
-  rimraf(contentPath(cache, address), cb)
+function rm (cache, address) {
+  return rimraf(contentPath(cache, address))
 }

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -1,104 +1,106 @@
 'use strict'
 
-var asyncMap = require('slide/lib/async-map')
-var contentPath = require('./content/path')
-var fixOwner = require('./util/fix-owner')
-var fs = require('graceful-fs')
-var lockfile = require('lockfile')
-var path = require('path')
-var pipe = require('mississippi').pipe
-var split = require('split')
-var through = require('mississippi').through
+const asyncMap = require('slide/lib/async-map')
+const contentPath = require('./content/path')
+const fixOwner = require('./util/fix-owner')
+const fs = require('graceful-fs')
+const lockfile = require('lockfile')
+const path = require('path')
+const pipe = require('mississippi').pipe
+const Promise = require('bluebird')
+const split = require('split')
+const through = require('mississippi').through
 
 module.exports.insert = insert
-function insert (cache, key, digest, opts, _cb) {
-  if (!_cb) {
-    _cb = opts
-    opts = null
-  }
+function insert (cache, key, digest, opts) {
   opts = opts || {}
-  var bucket = indexPath(cache, key)
-  var lock = bucket + '.lock'
-  var cb = function (err, entry) {
-    lockfile.unlock(lock, function (er) {
-      _cb(er || err, entry)
-    })
-  }
-  fixOwner.mkdirfix(path.dirname(bucket), opts.uid, opts.gid, function (err) {
-    if (err) { return _cb(err) }
-    lockfile.lock(lock, {
-      stale: 60000,
-      retries: 10,
-      wait: 10000
-    }, function (err) {
-      if (err) { return _cb(err) }
-      fs.stat(bucket, function (err, existing) {
-        if (err && err.code !== 'ENOENT' && err.code !== 'EPERM') { cb(err) }
-        var entry = {
-          key: key,
-          digest: digest,
-          time: +(new Date()),
-          metadata: opts.metadata
-        }
-        // Because of the way these entries work,
-        // the index is safe from fs.appendFile stopping
-        // mid-write so long as newlines are *prepended*
-        //
-        // That is, if a write fails, it will be ignored
-        // by `find`, and the next successful one will be
-        // used.
-        //
-        // This should be -very rare-, since `fs.appendFile`
-        // will often be atomic on most platforms unless
-        // very large metadata has been included, but caches
-        // like this one tend to last a long time. :)
-        // Most corrupted reads are likely to be from attempting
-        // to read the index while it's being written to --
-        // which is safe, but not guaranteed to be atomic.
-        var e = (existing ? '\n' : '') + JSON.stringify(entry)
-        fs.appendFile(bucket, e, function (err) {
-          if (err) { return cb(err) }
-          fixOwner.chownr(bucket, opts.uid, opts.gid, function (err) {
+  const bucket = indexPath(cache, key)
+  const lock = bucket + '.lock'
+  return fixOwner.mkdirfix(
+    path.dirname(bucket), opts.uid, opts.gid
+  ).then(() => (
+    Promise.fromNode(_cb => {
+      const cb = (err, entry) => {
+        lockfile.unlock(lock, er => {
+          _cb(err || er, entry)
+        })
+      }
+      lockfile.lock(lock, {
+        stale: 60000,
+        retries: 10,
+        wait: 10000
+      }, function (err) {
+        if (err) { return _cb(err) }
+        fs.stat(bucket, function (err, existing) {
+          if (err && err.code !== 'ENOENT' && err.code !== 'EPERM') {
+            return cb(err)
+          }
+          const entry = {
+            key: key,
+            digest: digest,
+            time: +(new Date()),
+            metadata: opts.metadata
+          }
+          // Because of the way these entries work,
+          // the index is safe from fs.appendFile stopping
+          // mid-write so long as newlines are *prepended*
+          //
+          // That is, if a write fails, it will be ignored
+          // by `find`, and the next successful one will be
+          // used.
+          //
+          // This should be -very rare-, since `fs.appendFile`
+          // will often be atomic on most platforms unless
+          // very large metadata has been included, but caches
+          // like this one tend to last a long time. :)
+          // Most corrupted reads are likely to be from attempting
+          // to read the index while it's being written to --
+          // which is safe, but not guaranteed to be atomic.
+          const e = (existing ? '\n' : '') + JSON.stringify(entry)
+          fs.appendFile(bucket, e, function (err) {
             cb(err, entry)
           })
         })
       })
     })
-  })
+  )).then(() => fixOwner.chownr(bucket, opts.uid, opts.gid))
 }
 
 module.exports.find = find
-function find (cache, key, cb) {
-  var bucket = indexPath(cache, key)
-  var stream = fs.createReadStream(bucket)
-  var ret
-  pipe(stream, split('\n', null, {trailing: true}).on('data', function (l) {
-    try {
-      var obj = JSON.parse(l)
-    } catch (e) {
-      return
-    }
-    if (obj && (obj.key === key)) {
-      ret = formatEntry(cache, obj)
-    }
-  }), function (err) {
-    if (err && err.code === 'ENOENT') {
-      cb(null, null)
-    } else {
-      cb(err, ret)
-    }
+function find (cache, key) {
+  const bucket = indexPath(cache, key)
+  const stream = fs.createReadStream(bucket)
+  let ret
+  return Promise.fromNode(cb => {
+    pipe(stream, split('\n', null, {trailing: true}).on('data', function (l) {
+      let obj
+      try {
+        obj = JSON.parse(l)
+      } catch (e) {
+        return
+      }
+      if (obj && (obj.key === key)) {
+        ret = formatEntry(cache, obj)
+      }
+    }), function (err) {
+      if (err && err.code === 'ENOENT') {
+        cb(null, null)
+      } else {
+        cb(err, ret)
+      }
+    })
   })
 }
 
 module.exports.delete = del
-function del (cache, key, cb) {
-  insert(cache, key, null, cb)
+function del (cache, key) {
+  return insert(cache, key, null)
 }
 
 module.exports.lsStream = lsStream
 function lsStream (cache) {
-  var indexPath = path.join(cache, 'index')
-  var stream = through.obj()
+  const indexPath = path.join(cache, 'index')
+  const stream = through.obj()
   fs.readdir(indexPath, function (err, files) {
     if (err && err.code === 'ENOENT') {
       return stream.end()
@@ -108,10 +110,11 @@ function lsStream (cache) {
       asyncMap(files, function (f, cb) {
         fs.readFile(path.join(indexPath, f), 'utf8', function (err, data) {
           if (err) { return cb(err) }
-          var entries = {}
+          const entries = {}
           data.split('\n').forEach(function (entry) {
+            let parsed
             try {
-              var parsed = JSON.parse(entry)
+              parsed = JSON.parse(entry)
             } catch (e) {
             }
             // NOTE - it's possible for an entry to be
@@ -136,18 +139,20 @@ function lsStream (cache) {
 }
 
 module.exports.ls = ls
-function ls (cache, cb) {
-  var entries = {}
-  lsStream(cache).on('finish', function () {
-    cb(null, entries)
-  }).on('data', function (d) {
-    entries[d.key] = d
-  }).on('error', cb)
+function ls (cache) {
+  const entries = {}
+  return Promise.fromNode(cb => {
+    lsStream(cache).on('finish', function () {
+      cb(null, entries)
+    }).on('data', function (d) {
+      entries[d.key] = d
+    }).on('error', cb)
+  })
 }
 
 module.exports.notFoundError = notFoundError
 function notFoundError (cache, key) {
-  var err = new Error('content not found')
+  const err = new Error('content not found')
   err.code = 'ENOENT'
   err.cache = cache
   err.key = key

--- a/lib/util/fix-owner.js
+++ b/lib/util/fix-owner.js
@@ -4,6 +4,7 @@ const Promise = require('bluebird')
 
 const chownr = Promise.promisify(require('chownr'))
 const mkdirp = Promise.promisify(require('mkdirp'))
+const inflight = require('promise-inflight')
 
 module.exports.chownr = fixOwner
 function fixOwner (filepath, uid, gid) {
@@ -20,17 +21,13 @@ function fixOwner (filepath, uid, gid) {
     // No need to override if it's already what we used.
     return Promise.resolve()
   }
-  // cb = inflight('fixOwner: fixing ownership on ' + filepath, cb)
-  // if (!cb) {
-  //   // We're inflight! whoosh!
-  //   return
-  // }
-
-  // *now* we override perms
-  return chownr(
-    filepath,
-    typeof uid === 'number' ? uid : process.getuid(),
-    typeof gid === 'number' ? gid : process.getgid()
+  return inflight(
+    'fixOwner: fixing ownership on ' + filepath,
+    () => chownr(
+      filepath,
+      typeof uid === 'number' ? uid : process.getuid(),
+      typeof gid === 'number' ? gid : process.getgid()
+    )
   )
 }
 

--- a/lib/util/fix-owner.js
+++ b/lib/util/fix-owner.js
@@ -1,45 +1,44 @@
 'use strict'
 
-var chownr = require('chownr')
-var dezalgo = require('dezalgo')
-var inflight = require('inflight')
-var mkdirp = require('mkdirp')
+const Promise = require('bluebird')
+
+const chownr = Promise.promisify(require('chownr'))
+const mkdirp = Promise.promisify(require('mkdirp'))
 
 module.exports.chownr = fixOwner
-function fixOwner (filepath, uid, gid, cb) {
-  cb = dezalgo(cb)
+function fixOwner (filepath, uid, gid) {
   if (!process.getuid) {
     // This platform doesn't need ownership fixing
-    return cb()
+    return Promise.resolve()
   }
   if (typeof uid !== 'number' && typeof gid !== 'number') {
     // There's no permissions override. Nothing to do here.
-    return cb()
+    return Promise.resolve()
   }
   if ((typeof uid === 'number' && process.getuid() === uid) &&
       (typeof gid === 'number' && process.getgid() === gid)) {
     // No need to override if it's already what we used.
-    return cb()
+    return Promise.resolve()
   }
-  cb = inflight('fixOwner: fixing ownership on ' + filepath, cb)
-  if (!cb) {
-    // We're inflight! whoosh!
-    return
-  }
+  // cb = inflight('fixOwner: fixing ownership on ' + filepath, cb)
+  // if (!cb) {
+  //   // We're inflight! whoosh!
+  //   return
+  // }
 
   // *now* we override perms
-  chownr(
+  return chownr(
     filepath,
     typeof uid === 'number' ? uid : process.getuid(),
-    typeof gid === 'number' ? gid : process.getgid(),
-    cb
+    typeof gid === 'number' ? gid : process.getgid()
   )
 }
 
 module.exports.mkdirfix = mkdirfix
 function mkdirfix (p, uid, gid, cb) {
-  mkdirp(p, function (err, made) {
-    if (err || !made) { return cb(err, made) }
-    fixOwner(made, uid, gid, cb)
+  return mkdirp(p).then(made => {
+    if (made) {
+      return fixOwner(made, uid, gid).then(() => made)
+    }
   })
 }

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,173 +1,168 @@
 'use strict'
 
-var asyncMap = require('slide').asyncMap
+const Promise = require('bluebird')
+
 var checksumStream = require('checksum-stream')
 var fixOwner = require('./util/fix-owner')
 var fs = require('graceful-fs')
 var index = require('./entry-index')
-var lockfile = require('lockfile')
+var lockfile = Promise.promisifyAll(require('lockfile'))
 var path = require('path')
-var pipe = require('mississippi').pipe
-var rimraf = require('rimraf')
+var pipe = Promise.promisify(require('mississippi').pipe)
+var rimraf = Promise.promisify(require('rimraf'))
+
+Promise.promisifyAll(fs)
 
 module.exports = verify
-function verify (cache, opts, _cb) {
-  if (!_cb) {
-    _cb = opts
-    opts = null
-  }
+function verify (cache, opts) {
   opts = opts || {}
-  var lock = path.join(cache, 'verify.lock')
-  var cb = function (err, stats) {
-    lockfile.unlock(lock, function (er) {
-      _cb(er || err, stats)
+  opts.log && opts.log.verbose('verify', 'verifying content cache at', cache)
+  const startTime = +(new Date())
+  return fixOwner.mkdirfix(
+    cache, opts.uid, opts.gid
+  ).then(() => {
+    const lockPath = path.join(cache, 'verify.lock')
+    const lock = lockfile.lockAsync(lockPath).disposer(() => {
+      return lockfile.unlock(lockPath)
     })
-  }
-  fixOwner.mkdirfix(cache, opts.uid, opts.gid, function (err) {
-    if (err) { return _cb(err) }
-    lockfile.lock(lock, function (err) {
-      if (err) { return _cb(err) }
-      garbageCollect(cache, opts, function (err, gcStats) {
-        if (err) { return cb(err) }
-        tidyIndex(cache, opts, function (err, tidyStats) {
-          if (err) { return cb(err) }
+    return Promise.using(lock, () => {
+      return garbageCollect(cache, opts).then(gcStats => {
+        return tidyIndex(cache, opts).then(tidyStats => {
           var stats = tidyStats
           Object.keys(gcStats).forEach(function (key) {
             stats[key] = gcStats[key]
           })
-          var verifile = path.join(cache, '_lastverified')
-          fs.writeFile(verifile, '' + (+(new Date())), function (err) {
-            if (err) { return cb(err) }
-            fixOwner.chownr(cache, opts.uid, opts.gid, function (err) {
-              if (err) { return cb(err) }
-              rimraf(path.join(cache, 'tmp'), function (err) {
-                if (err) { return cb(err) }
-                cb(null, stats)
-              })
-            })
-          })
+          return stats
         })
+      }).then(stats => {
+        var verifile = path.join(cache, '_lastverified')
+        opts.log && opts.log.verbose('verify', 'writing verifile to ' + verifile)
+        return fs.writeFileAsync(
+          verifile, '' + (+(new Date()))
+        ).then(() => {
+          opts.log && opts.log.verbose('verify', 'fixing cache ownership')
+          return fixOwner.chownr(cache, opts.uid, opts.gid)
+        }).then(() => {
+          opts.log && opts.log.verbose('verify', 'clearing out tmp')
+          return rimraf(path.join(cache, 'tmp'))
+        }).then(() => stats)
       })
     })
+  }).then(stats => {
+    stats.runTime = (+(new Date()) - startTime) / 1000
+    opts.log && opts.log.verbose('verify', 'final stats:', stats)
+    return stats
   })
 }
 
-function tidyIndex (cache, opts, cb) {
-  index.ls(cache, function (err, entries) {
-    if (err) { return cb(err) }
-    rimraf(path.join(cache, 'index'), function (err) {
-      if (err) { return cb(err) }
+function tidyIndex (cache, opts) {
+  opts.log && opts.log.verbose('verify', 'tidying index')
+  return index.ls(cache).then(entries => {
+    return rimraf(path.join(cache, 'index')).then(() => {
       var stats = {
         entriesRemoved: 0,
         digestMissing: 0,
         totalEntries: 0
       }
-      asyncMap(Object.keys(entries), function (key, cb) {
+      return Promise.reduce(Object.keys(entries), (stats, key) => {
         var entry = entries[key]
         if (!entry.digest) {
           stats.digestMissing++
-          return cb()
+          return stats
         }
         var content = path.join(cache, 'content', entries[key].digest)
-        fs.stat(content, function (err) {
-          if (err && err.code === 'ENOENT') {
-            stats.entriesRemoved++
-            return cb()
-          } else {
-            stats.totalEntries++
-            index.insert(cache, key, entry.digest, {
-              uid: opts.uid,
-              gid: opts.gid,
-              metadata: entry.metadata
-            }, cb)
+        return fs.statAsync(content).catch(err => {
+          if (err.code === 'ENOENT') {
+            stats.entriesRemoves++
+            return stats
           }
+        }).then(() => {
+          stats.totalEntries++
+          return index.insert(cache, key, entry.digest, {
+            uid: opts.uid,
+            gid: opts.gid,
+            metadata: entry.metadata
+          }).then(() => stats)
         })
-      }, function (err) {
-        if (err) { return cb(err) }
-        cb(null, stats)
-      })
+      }, stats)
     })
   })
 }
 
-function garbageCollect (cache, opts, cb) {
-  index.ls(cache, function (err, entries) {
+function garbageCollect (cache, opts) {
+  opts.log && opts.log.verbose('verify', 'garbage collecting content')
+  return index.ls(cache).then(entries => {
     var byDigest = {}
     Object.keys(entries).forEach(function (k) {
       byDigest[entries[k].digest] = entries[k]
     })
-    if (err) { return cb(err) }
-    var stats = {
-      verifiedContent: 0,
-      collectedCount: 0,
-      reclaimedSize: 0
-    }
     var contentDir = path.join(cache, 'content')
-    fs.readdir(contentDir, function (err, files) {
-      if (err && err.code === 'ENOENT') {
-        return cb(null, stats)
-      } else if (err) {
-        return cb(err)
+    return fs.readdirAsync(contentDir).catch(err => {
+      if (err.code === 'ENOENT') {
+        return
       } else {
-        asyncMap(files, function (f, cb) {
-          var fullPath = path.join(contentDir, f)
-          if (byDigest[f]) {
-            var algo = opts.hashAlgorithm || 'sha1'
-            verifyContent(fullPath, algo, function (err, collected) {
-              if (err) { return cb(err) }
-              if (collected != null) {
-                stats.collectedCount++
-                stats.reclaimedSize += collected
-              } else {
-                stats.verifiedContent++
-              }
-              cb()
-            })
-          } else {
-            stats.collectedCount++
-            fs.stat(fullPath, function (err, s) {
-              if (err) { return cb(err) }
-              stats.reclaimedSize += s.size
-              rimraf(path.join(contentDir, f), cb)
-            })
-          }
-        }, function (err) {
-          if (err) { return cb(err) }
-          cb(null, stats)
-        })
+        throw err
       }
+    }).then(files => {
+      var stats = {
+        verifiedContent: 0,
+        collectedCount: 0,
+        reclaimedSize: 0,
+        keptSize: 0
+      }
+      return Promise.reduce(files, (stats, f) => {
+        var fullPath = path.join(contentDir, f)
+        if (byDigest[f]) {
+          var algo = opts.hashAlgorithm || 'sha1'
+          return verifyContent(fullPath, algo).then(info => {
+            if (!info.valid) {
+              stats.collectedCount++
+              stats.reclaimedSize += info.size
+            } else {
+              stats.verifiedContent++
+              stats.keptSize += info.size
+            }
+            return stats
+          })
+        } else {
+          stats.collectedCount++
+          return fs.statAsync(fullPath).then(s => {
+            stats.reclaimedSize += s.size
+            return rimraf(path.join(contentDir, f)).then(() => stats)
+          })
+        }
+      }, stats)
     })
   })
 }
 
-function verifyContent (filepath, algo, cb) {
-  fs.stat(filepath, function (err, stat) {
-    if (err) { return cb(err) }
+function verifyContent (filepath, algo) {
+  return fs.statAsync(filepath).then(stat => {
     var reader = fs.createReadStream(filepath)
     var checksummer = checksumStream({
       digest: path.basename(filepath),
       algorithm: algo
     })
-    checksummer.on('data', function () {})
-    pipe(reader, checksummer, function (err) {
+    var contentInfo = {
+      size: stat.size,
+      valid: true
+    }
+    checksummer.on('data', () => {})
+    return pipe(reader, checksummer).catch(err => {
       if (err && err.code === 'EBADCHECKSUM') {
-        rimraf(filepath, function (err) {
-          if (err) { return cb(err) }
-          cb(null, stat.size)
+        return rimraf(filepath).then(() => {
+          contentInfo.valid = false
         })
-      } else if (err) {
-        return cb(err)
       } else {
-        cb(null, null)
+        throw err
       }
-    })
+    }).then(() => contentInfo)
   })
 }
 
 module.exports.lastRun = lastRun
-function lastRun (cache, cb) {
-  fs.readFile(path.join(cache, '_lastverified'), 'utf8', function (err, data) {
-    if (err) { return cb(err) }
-    cb(null, new Date(+data))
-  })
+function lastRun (cache) {
+  return fs.readFileAsync(
+    path.join(cache, '_lastverified'), 'utf8'
+  ).then(data => new Date(+data))
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "chownr": "^1.0.1",
     "dezalgo": "^1.0.3",
     "graceful-fs": "^4.1.10",
-    "inflight": "^1.0.6",
     "lockfile": "^1.0.2",
     "mississippi": "^1.2.0",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "mississippi": "^1.2.0",
     "mkdirp": "^0.5.1",
     "once": "^1.4.0",
+    "promise-inflight": "^1.0.1",
     "rimraf": "^2.5.4",
     "slide": "^1.1.6",
     "split": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preversion": "npm t",
     "postversion": "npm publish && git push --follow-tags",
     "pretest": "standard lib test *.js",
-    "test": "nyc -- tap test/*.js",
+    "test": "nyc -- tap -J test/*.js",
     "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
     "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
     "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   ],
   "license": "CC0-1.0",
   "dependencies": {
+    "bluebird": "^3.4.7",
     "checksum-stream": "^1.0.2",
     "chownr": "^1.0.1",
     "dezalgo": "^1.0.3",

--- a/rm.js
+++ b/rm.js
@@ -1,20 +1,22 @@
 'use strict'
 
-var rmContent = require('./lib/content/rm')
-var index = require('./lib/entry-index')
-var rimraf = require('rimraf')
+const Promise = require('bluebird')
+
+const rmContent = require('./lib/content/rm')
+const index = require('./lib/entry-index')
+const rimraf = Promise.promisify(require('rimraf'))
 
 module.exports.all = all
-function all (cache, cb) {
-  rimraf(cache, cb)
+function all (cache) {
+  return rimraf(cache)
 }
 
 module.exports.entry = entry
-function entry (cache, key, cb) {
-  index.delete(cache, key, cb)
+function entry (cache, key) {
+  return index.delete(cache, key)
 }
 
 module.exports.content = content
-function content (cache, address, cb) {
-  rmContent(cache, address, cb)
+function content (cache, address) {
+  return rmContent(cache, address)
 }

--- a/test/content.rm.js
+++ b/test/content.rm.js
@@ -1,42 +1,45 @@
 'use strict'
 
-var fs = require('graceful-fs')
-var path = require('path')
-var Tacks = require('tacks')
-var test = require('tap').test
-var testDir = require('./util/test-dir')(__filename)
+const fs = require('graceful-fs')
+const path = require('path')
+const Promise = require('bluebird')
+const Tacks = require('tacks')
+const test = require('tap').test
+const testDir = require('./util/test-dir')(__filename)
 
-var CACHE = path.join(testDir, 'cache')
-var Dir = Tacks.Dir
-var File = Tacks.File
-var rm = require('../lib/content/rm')
+Promise.promisifyAll(fs)
+
+const CACHE = path.join(testDir, 'cache')
+const Dir = Tacks.Dir
+const File = Tacks.File
+const rm = require('../lib/content/rm')
 
 test('removes a content entry', function (t) {
-  var fixture = new Tacks(Dir({
+  const fixture = new Tacks(Dir({
     'content': Dir({
       'deadbeef': File('')
     })
   }))
   fixture.create(CACHE)
-  rm(CACHE, 'deadbeef', function (err) {
-    t.ifError(err, 'rm ran without error')
-    fs.stat(path.join(CACHE, 'content', 'deadbeef'), function (err) {
-      t.ok(err, 'fs.stat failed on rmed content')
-      t.equal('ENOENT', err.code, 'file does not exist anymore')
-      t.end()
-    })
+  return rm(CACHE, 'deadbeef').then(() => (
+    fs.statAsync(path.join(CACHE, 'content', 'deadbeef'))
+  )).then(() => {
+    throw new Error('expected an error')
+  }).catch(err => {
+    t.ok(err, 'fs.stat failed on rmed content')
+    t.equal('ENOENT', err.code, 'file does not exist anymore')
   })
 })
 
 test('works fine if entry missing', function (t) {
-  var fixture = new Tacks(Dir({}))
+  const fixture = new Tacks(Dir({}))
   fixture.create(CACHE)
-  rm(CACHE, 'deadbeef', function (err) {
-    t.ifError(err, 'rm ran without error')
-    fs.stat(path.join(CACHE, 'content', 'deadbeef'), function (err) {
-      t.ok(err, 'fs.stat failed on rmed content')
-      t.equal('ENOENT', err.code, 'file does not exist anymore')
-      t.end()
-    })
+  return rm(CACHE, 'deadbeef').then(() => (
+    fs.statAsync(path.join(CACHE, 'content', 'deadbeef'))
+  )).then(() => {
+    throw new Error('expected an error')
+  }).catch(err => {
+    t.ok(err, 'fs.stat failed on rmed content')
+    t.equal('ENOENT', err.code, 'file does not exist anymore')
   })
 })

--- a/test/index.ls.js
+++ b/test/index.ls.js
@@ -1,19 +1,18 @@
 'use strict'
 
-var CacheIndex = require('./util/cache-index')
-var fs = require('fs')
-var path = require('path')
-var Tacks = require('tacks')
-var test = require('tap').test
-var testDir = require('./util/test-dir')(__filename)
+const CacheIndex = require('./util/cache-index')
+const path = require('path')
+const Tacks = require('tacks')
+const test = require('tap').test
+const testDir = require('./util/test-dir')(__filename)
 
-var CACHE = path.join(testDir, 'cache')
-var contentPath = require('../lib/content/path')
-var Dir = Tacks.Dir
-var index = require('../lib/entry-index')
+const CACHE = path.join(testDir, 'cache')
+const contentPath = require('../lib/content/path')
+const Dir = Tacks.Dir
+const index = require('../lib/entry-index')
 
 test('basic listing', function (t) {
-  var contents = {
+  const contents = {
     'whatever': {
       key: 'whatever',
       digest: 'deadbeef',
@@ -27,7 +26,7 @@ test('basic listing', function (t) {
       metadata: null
     }
   }
-  var fixture = new Tacks(Dir({
+  const fixture = new Tacks(Dir({
     'index': CacheIndex(contents)
   }))
   contents.whatever.path =
@@ -35,15 +34,13 @@ test('basic listing', function (t) {
   contents.whatnot.path =
     contentPath(CACHE, contents.whatnot.digest)
   fixture.create(CACHE)
-  index.ls(CACHE, function (err, listing) {
-    if (err) { throw err }
+  return index.ls(CACHE).then(listing => {
     t.deepEqual(listing, contents, 'index contents correct')
-    t.end()
   })
 })
 
 test('separate keys in conflicting buckets', function (t) {
-  var contents = {
+  const contents = {
     'whatever': {
       key: 'whatever',
       digest: 'deadbeef',
@@ -57,7 +54,7 @@ test('separate keys in conflicting buckets', function (t) {
       metadata: null
     }
   }
-  var fixture = new Tacks(Dir({
+  const fixture = new Tacks(Dir({
     'index': CacheIndex({
       // put both in the same bucket
       'whatever': [contents.whatever, contents.whatev]
@@ -68,17 +65,13 @@ test('separate keys in conflicting buckets', function (t) {
   contents.whatev.path =
     contentPath(CACHE, contents.whatev.digest)
   fixture.create(CACHE)
-  index.ls(CACHE, function (err, listing) {
-    if (err) { throw err }
+  return index.ls(CACHE).then(listing => {
     t.deepEqual(listing, contents, 'index contents correct')
-    t.end()
   })
 })
 
 test('works fine on an empty/missing cache', function (t) {
-  index.ls(CACHE, function (err, listing) {
-    if (err) { throw err }
+  return index.ls(CACHE).then(listing => {
     t.deepEqual(listing, {})
-    t.end()
   })
 })

--- a/test/util/test-dir.js
+++ b/test/util/test-dir.js
@@ -1,32 +1,28 @@
 'use strict'
 
-var mkdirp = require('mkdirp')
-var path = require('path')
-var rimraf = require('rimraf')
-var tap = require('tap')
+const mkdirp = require('mkdirp')
+const path = require('path')
+const rimraf = require('rimraf')
+const tap = require('tap')
 
-var cacheDir = path.resolve(__dirname, '../cache')
+const cacheDir = path.resolve(__dirname, '../cache')
 
 module.exports = testDir
 function testDir (filename) {
-  var base = path.basename(filename, '.js')
-  var dir = path.join(cacheDir, base)
-  tap.beforeEach(function (cb) {
-    reset(dir, function (err) {
+  const base = path.basename(filename, '.js')
+  const dir = path.join(cacheDir, base)
+  tap.beforeEach(cb => {
+    reset(dir, err => {
       if (err) { throw err }
       cb()
     })
   })
   if (!process.env.KEEPCACHE) {
-    tap.tearDown(function () {
+    tap.tearDown(() => {
       process.chdir(__dirname)
-      try {
-        rimraf.sync(dir)
-      } catch (e) {
-        if (process.platform !== 'win32') {
-          throw e
-        }
-      }
+      // This is ok cause this is the last
+      // thing to run in the process
+      rimraf(dir, () => {})
     })
   }
   return dir


### PR DESCRIPTION
Fixes: #34
Fixes: #35 

This patch changes the entire cacache API over to using streams and Promises as its async APIs. This means no more callbacks. This is a very very breaking change, but hopefully will help simplify some bits of the code, and at least help make things more predictable than they are in a few cases right now.

I'm a bit worried about performance, but I think it's still a good idea.

### TODO

- [x] utils
- [x] entry index
- [x] content/put-stream
- [x] content/read
- [x] content/rm
- [x] verify
- [x] test suite
- [x] toplevel APIs
- [x] documentation