### PR TITLE
Add memoization support

### DIFF
--- a/get.js
+++ b/get.js
@@ -4,7 +4,9 @@ const Promise = require('bluebird')
 
 const index = require('./lib/entry-index')
 const finished = Promise.promisify(require('mississippi').finished)
+const memo = require('./lib/memoization')
 const pipe = require('mississippi').pipe
+const pipeline = require('mississippi').pipeline
 const read = require('./lib/content/read')
 const through = require('mississippi').through
 
@@ -16,39 +18,137 @@ module.exports.byDigest = function getByDigest (cache, digest, opts) {
 }
 function getData (byDigest, cache, key, opts) {
   opts = opts || {}
-  const src = (byDigest ? getStream.byDigest : getStream)(cache, key, opts)
-  let data = ''
-  let meta
-  src.on('data', function (d) { data += d })
-  src.on('metadata', function (m) { meta = m })
-  return finished(src).then(() => ({ data, meta }))
+  opts.hashAlgorithm = opts.hashAlgorithm || 'sha1'
+  const memoized = (
+    byDigest
+    ? memo.get.byDigest(cache, key, opts.hashAlgorithm)
+    : memo.get(cache, key)
+  )
+  if (memoized && opts.memoize !== false) {
+    return Promise.resolve({
+      metadata: memoized.entry.metadata,
+      data: memoized.data,
+      digest: memoized.entry.digest,
+      hashAlgorithm: memoized.entry.hashAlgorithm
+    })
+  }
+  const src = (byDigest ? getStreamDigest : getStream)(cache, key, opts)
+  let acc = []
+  let dataTotal = 0
+  let metadata
+  let digest
+  let hashAlgorithm
+  if (!byDigest) {
+    src.on('digest', d => {
+      digest = d
+    })
+    src.on('hashAlgorithm', d => { hashAlgorithm = d })
+    src.on('metadata', d => { metadata = d })
+  }
+  src.on('data', d => {
+    acc.push(d)
+    dataTotal += d.length
+  })
+  return finished(src).then(() => {
+    const data = Buffer.concat(acc, dataTotal)
+    return byDigest ? data : { metadata, data, digest, hashAlgorithm }
+  })
 }
 
 module.exports.stream = getStream
-module.exports.stream.byDigest = read.readStream
 function getStream (cache, key, opts) {
-  const stream = through()
-  index.find(cache, key).catch(err => {
-    stream.emit('error', err)
-  }).then(data => {
-    if (!data) {
+  opts = opts || {}
+  let stream = through()
+  const memoized = memo.get(cache, key)
+  if (memoized && opts.memoize !== false) {
+    stream.on('newListener', function (ev, cb) {
+      ev === 'metadata' && cb(memoized.entry.metadata)
+      ev === 'digest' && cb(memoized.entry.digest)
+      ev === 'hashAlgorithm' && cb(memoized.entry.hashAlgorithm)
+    })
+    stream.write(memoized.data, () => stream.end())
+    return stream
+  }
+  index.find(cache, key).then(entry => {
+    if (!entry) {
       return stream.emit(
         'error', index.notFoundError(cache, key)
       )
     }
-    stream.emit('metadata', data)
+    let memoStream
+    if (opts.memoize) {
+      let memoData = []
+      let memoLength = 0
+      memoStream = through((c, en, cb) => {
+        memoData && memoData.push(c)
+        memoLength += c.length
+        cb(null, c, en)
+      }, cb => {
+        memoData && memo.put(cache, entry, Buffer.concat(memoData, memoLength))
+        cb()
+      })
+    } else {
+      memoStream = through()
+    }
+    // TODO - don't overwrite someone else's `opts`.
+    opts.hashAlgorithm = entry.hashAlgorithm
+    stream.emit('metadata', entry.metadata)
+    stream.emit('hashAlgorithm', entry.hashAlgorithm)
+    stream.emit('digest', entry.digest)
     stream.on('newListener', function (ev, cb) {
-      ev === 'metadata' && cb(data)
+      ev === 'metadata' && cb(entry.metadata)
+      ev === 'digest' && cb(entry.digest)
+      ev === 'hashAlgorithm' && cb(entry.hashAlgorithm)
     })
     pipe(
-      read.readStream(cache, data.digest, opts),
+      read.readStream(cache, entry.digest, opts),
+      memoStream,
       stream
     )
-  })
+  }, err => stream.emit('error', err))
   return stream
 }
 
+module.exports.stream.byDigest = getStreamDigest
+function getStreamDigest (cache, digest, opts) {
+  opts = opts || {}
+  opts.hashAlgorithm = opts.hashAlgorithm || 'sha1'
+  const memoized = memo.get.byDigest(cache, digest, opts.hashAlgorithm)
+  if (memoized && opts.memoize !== false) {
+    const stream = through()
+    stream.write(memoized, () => stream.end())
+    return stream
+  } else {
+    let stream = read.readStream(cache, digest, opts)
+    if (opts.memoize) {
+      let memoData = []
+      let memoLength = 0
+      const memoStream = through((c, en, cb) => {
+        memoData && memoData.push(c)
+        memoLength += c.length
+        cb(null, c, en)
+      }, cb => {
+        memoData && memo.put.byDigest(
+          cache,
+          digest,
+          opts.hashAlgorithm,
+          Buffer.concat(memoData, memoLength)
+        )
+        cb()
+      })
+      stream = pipeline(stream, memoStream)
+    }
+    return stream
+  }
+}
+
 module.exports.info = info
-function info (cache, key) {
-  return index.find(cache, key)
+function info (cache, key, opts) {
+  opts = opts || {}
+  const memoized = memo.get(cache, key)
+  if (memoized && opts.memoize !== false) {
+    return Promise.resolve(memoized.entry)
+  } else {
+    return index.find(cache, key)
+  }
 }

--- a/index.js
+++ b/index.js
@@ -5,5 +5,6 @@ module.exports = {
   get: require('./get'),
   put: require('./put'),
   rm: require('./rm'),
-  verify: require('./verify')
+  verify: require('./verify'),
+  clearMemoized: require('./lib/memoization').clearMemoized
 }

--- a/lib/content/put-stream.js
+++ b/lib/content/put-stream.js
@@ -115,7 +115,7 @@ function pipeToTmp (inputStream, cache, tmpTarget, opts, errCheck) {
       pipe(inputStream, hashStream, outStream, err => {
         errCheck()
         if (err) {
-          reject(err)
+          rimraf(tmpTarget).then(() => reject(err), reject)
         } else {
           resolve(digest)
         }

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -38,6 +38,7 @@ function insert (cache, key, digest, opts) {
           const entry = {
             key: key,
             digest: digest,
+            hashAlgorithm: opts.hashAlgorithm,
             time: +(new Date()),
             metadata: opts.metadata
           }
@@ -63,7 +64,11 @@ function insert (cache, key, digest, opts) {
         })
       })
     })
-  )).then(() => fixOwner.chownr(bucket, opts.uid, opts.gid))
+  )).then(entry => {
+    return fixOwner.chownr(bucket, opts.uid, opts.gid).then(() => {
+      return formatEntry(cache, entry)
+    })
+  })
 }
 
 module.exports.find = find
@@ -173,6 +178,7 @@ function formatEntry (cache, entry) {
   return {
     key: entry.key,
     digest: entry.digest,
+    hashAlgorithm: entry.hashAlgorithm,
     path: contentPath(cache, entry.digest),
     time: entry.time,
     metadata: entry.metadata

--- a/lib/memoization.js
+++ b/lib/memoization.js
@@ -1,0 +1,31 @@
+'use strict'
+
+let MEMOIZED = {}
+
+module.exports.clearMemoized = clearMemoized
+function clearMemoized () {
+  var old = MEMOIZED
+  MEMOIZED = {}
+  return old
+}
+
+module.exports.put = put
+function put (cache, entry, data) {
+  MEMOIZED[`key:${cache}:${entry.key}`] = { entry, data }
+  putDigest(cache, entry.digest, entry.hashAlgorithm, data)
+}
+
+module.exports.put.byDigest = putDigest
+function putDigest (cache, digest, algo, data) {
+  MEMOIZED[`digest:${cache}:${algo}:${digest}`] = data
+}
+
+module.exports.get = get
+function get (cache, key) {
+  return MEMOIZED[`key:${cache}:${key}`]
+}
+
+module.exports.get.byDigest = getDigest
+function getDigest (cache, digest, algo) {
+  return MEMOIZED[`digest:${cache}:${algo}:${digest}`]
+}

--- a/rm.js
+++ b/rm.js
@@ -2,21 +2,25 @@
 
 const Promise = require('bluebird')
 
-const rmContent = require('./lib/content/rm')
 const index = require('./lib/entry-index')
+const memo = require('./lib/memoization')
 const rimraf = Promise.promisify(require('rimraf'))
+const rmContent = require('./lib/content/rm')
 
 module.exports.all = all
 function all (cache) {
+  memo.clearMemoized()
   return rimraf(cache)
 }
 
 module.exports.entry = entry
 function entry (cache, key) {
+  memo.clearMemoized()
   return index.delete(cache, key)
 }
 
 module.exports.content = content
 function content (cache, address) {
+  memo.clearMemoized()
   return rmContent(cache, address)
 }

--- a/test/content.read.js
+++ b/test/content.read.js
@@ -35,7 +35,7 @@ test('readStream: returns a stream with cache content data', function (t) {
 
 test('readStream: allows hashAlgorithm configuration', function (t) {
   const CONTENT = 'foobarbaz'
-  const HASH = 'sha1'
+  const HASH = 'sha512'
   const DIGEST = crypto.createHash(HASH).update(CONTENT).digest('hex')
   const dir = {}
   dir[DIGEST] = File(CONTENT)
@@ -48,7 +48,7 @@ test('readStream: allows hashAlgorithm configuration', function (t) {
   let buf = ''
   stream.on('data', function (data) { buf += data })
   stream.on('end', function () {
-    t.ok(true, 'stream completed successfully, off a sha1')
+    t.ok(true, 'stream completed successfully, off a sha512')
     t.equal(CONTENT, buf, 'cache contents read correctly')
     t.end()
   })

--- a/test/get.js
+++ b/test/get.js
@@ -1,0 +1,315 @@
+'use strict'
+
+const Promise = require('bluebird')
+
+const crypto = require('crypto')
+const finished = Promise.promisify(require('mississippi').finished)
+const index = require('../lib/entry-index')
+const memo = require('../lib/memoization')
+const path = require('path')
+const rimraf = Promise.promisify(require('rimraf'))
+const Tacks = require('tacks')
+const test = require('tap').test
+const testDir = require('./util/test-dir')(__filename)
+
+const Dir = Tacks.Dir
+const File = Tacks.File
+
+const CACHE = path.join(testDir, 'cache')
+const CONTENT = bufferise('foobarbaz')
+const KEY = 'my-test-key'
+const ALGO = 'sha512'
+const DIGEST = crypto.createHash(ALGO).update(CONTENT).digest('hex')
+const METADATA = { foo: 'bar' }
+
+var get = require('../get')
+
+function bufferise (string) {
+  return Buffer.from
+  ? Buffer.from(string, 'utf8')
+  : new Buffer(string, 'utf8')
+}
+
+// Simple wrapper util cause this gets WORDY
+function streamGet (byDigest) {
+  const args = [].slice.call(arguments, 1)
+  let data = []
+  let dataLen = 0
+  let hashAlgorithm
+  let digest
+  let metadata
+  const stream = (
+    byDigest ? get.stream.byDigest : get.stream
+  ).apply(null, args)
+  stream.on('data', d => {
+    data.push(d)
+    dataLen += d.length
+  }).on('hashAlgorithm', h => {
+    hashAlgorithm = h
+  }).on('digest', d => {
+    digest = d
+  }).on('metadata', m => {
+    metadata = m
+  })
+  return finished(stream).then(() => ({
+    data: Buffer.concat(data, dataLen), hashAlgorithm, digest, metadata
+  }))
+}
+
+test('basic bulk get', t => {
+  const fixture = new Tacks(Dir({
+    'content': Dir({
+      [DIGEST]: File(CONTENT)
+    })
+  }))
+  fixture.create(CACHE)
+  return index.insert(CACHE, KEY, DIGEST, {
+    metadata: METADATA,
+    hashAlgorithm: ALGO
+  }).then(() => {
+    return get(CACHE, KEY)
+  }).then(res => {
+    t.deepEqual(res, {
+      metadata: METADATA,
+      data: CONTENT,
+      hashAlgorithm: ALGO,
+      digest: DIGEST
+    }, 'bulk key get returned proper data')
+  }).then(() => {
+    return get.byDigest(CACHE, DIGEST, {hashAlgorithm: ALGO})
+  }).then(res => {
+    t.deepEqual(res, CONTENT, 'byDigest returned proper data')
+  })
+})
+
+test('basic stream get', t => {
+  const fixture = new Tacks(Dir({
+    'content': Dir({
+      [DIGEST]: File(CONTENT)
+    })
+  }))
+  fixture.create(CACHE)
+  return index.insert(CACHE, KEY, DIGEST, {
+    metadata: METADATA,
+    hashAlgorithm: ALGO
+  }).then(() => {
+    return Promise.join(
+      streamGet(false, CACHE, KEY),
+      streamGet(true, CACHE, DIGEST, { hashAlgorithm: ALGO }),
+      (byKey, byDigest) => {
+        t.deepEqual(byKey, {
+          data: CONTENT,
+          hashAlgorithm: ALGO,
+          digest: DIGEST,
+          metadata: METADATA
+        }, 'got all expected data and fields from key fetch')
+        t.deepEqual(
+          byDigest.data,
+          CONTENT,
+          'got correct data from digest fetch'
+        )
+      }
+    )
+  })
+})
+
+test('ENOENT if not found', t => {
+  return get(CACHE, KEY).then(() => {
+    throw new Error('lookup should fail')
+  }).catch(err => {
+    t.ok(err, 'got an error')
+    t.equal(err.code, 'ENOENT', 'error code is ENOENT')
+    return get.info(CACHE, KEY)
+  }).catch(err => {
+    t.ok(err, 'got an error')
+    t.equal(err.code, 'ENOENT', 'error code is ENOENT')
+  })
+})
+
+test('get.info index entry lookup', t => {
+  return index.insert(CACHE, KEY, DIGEST, {
+    metadata: METADATA,
+    hashAlgorithm: ALGO
+  }).then(ENTRY => {
+    return get.info(CACHE, KEY).then(entry => {
+      t.deepEqual(entry, ENTRY, 'get.info() returned the right entry')
+    })
+  })
+})
+
+test('memoizes data on bulk read', t => {
+  memo.clearMemoized()
+  const fixture = new Tacks(Dir({
+    'content': Dir({
+      [DIGEST]: File(CONTENT)
+    })
+  }))
+  fixture.create(CACHE)
+  return index.insert(CACHE, KEY, DIGEST, {
+    metadata: METADATA,
+    hashAlgorithm: ALGO
+  }).then(ENTRY => {
+    return get(CACHE, KEY).then(() => {
+      t.deepEqual(memo.get(CACHE, KEY), null, 'no memoization!')
+      return get(CACHE, KEY, { memoize: true })
+    }).then(res => {
+      t.deepEqual(res, {
+        metadata: METADATA,
+        data: CONTENT,
+        hashAlgorithm: ALGO,
+        digest: DIGEST
+      }, 'usual data returned')
+      t.deepEqual(memo.get(CACHE, KEY), {
+        entry: ENTRY,
+        data: CONTENT
+      }, 'data inserted into memoization cache')
+      return rimraf(CACHE)
+    }).then(() => {
+      return get(CACHE, KEY)
+    }).then(res => {
+      t.deepEqual(res, {
+        metadata: METADATA,
+        data: CONTENT,
+        hashAlgorithm: ALGO,
+        digest: DIGEST
+      }, 'memoized data fetched by default')
+      return get(CACHE, KEY, { memoize: false }).then(() => {
+        throw new Error('expected get to fail')
+      }).catch(err => {
+        t.ok(err, 'got an error from unmemoized get')
+        t.equal(err.code, 'ENOENT', 'cached content not found')
+        t.deepEqual(memo.get(CACHE, KEY), {
+          entry: ENTRY,
+          data: CONTENT
+        }, 'data still in memoization cache')
+      })
+    })
+  })
+})
+
+test('memoizes data on stream read', t => {
+  memo.clearMemoized()
+  const fixture = new Tacks(Dir({
+    'content': Dir({
+      [DIGEST]: File(CONTENT)
+    })
+  }))
+  fixture.create(CACHE)
+  return index.insert(CACHE, KEY, DIGEST, {
+    metadata: METADATA,
+    hashAlgorithm: ALGO
+  }).then(ENTRY => {
+    return Promise.join(
+      streamGet(false, CACHE, KEY),
+      streamGet(true, CACHE, DIGEST, { hashAlgorithm: ALGO }),
+      () => {
+        t.deepEqual(memo.get(CACHE, KEY), null, 'no memoization by key!')
+        t.deepEqual(
+          memo.get.byDigest(CACHE, DIGEST, ALGO),
+          null,
+          'no memoization by digest!'
+        )
+      }
+    ).then(() => {
+      memo.clearMemoized()
+      return streamGet(true, CACHE, DIGEST, {
+        memoize: true,
+        hashAlgorithm: ALGO
+      })
+    }).then(byDigest => {
+      t.deepEqual(byDigest.data, CONTENT, 'usual data returned from stream')
+      t.deepEqual(memo.get(CACHE, KEY), null, 'digest fetch = no key entry')
+      t.deepEqual(
+        memo.get.byDigest(CACHE, DIGEST, ALGO),
+        CONTENT,
+        'content memoized'
+      )
+      t.deepEqual(
+        memo.get.byDigest(CACHE, DIGEST, 'sha1'),
+        null,
+        'content memoization filtered by hashAlgo'
+      )
+      t.deepEqual(
+        memo.get.byDigest('whatev', DIGEST, ALGO),
+        null,
+        'content memoization filtered by cache'
+      )
+    }).then(() => {
+      memo.clearMemoized()
+      return streamGet(false, CACHE, KEY, { memoize: true })
+    }).then(byKey => {
+      t.deepEqual(byKey, {
+        metadata: METADATA,
+        data: CONTENT,
+        hashAlgorithm: ALGO,
+        digest: DIGEST
+      }, 'usual data returned from key fetch')
+      t.deepEqual(memo.get(CACHE, KEY), {
+        entry: ENTRY,
+        data: CONTENT
+      }, 'data inserted into memoization cache')
+      t.deepEqual(
+        memo.get.byDigest(CACHE, DIGEST, ALGO),
+        CONTENT,
+        'content memoized by digest, too'
+      )
+      t.deepEqual(
+        memo.get('whatev', KEY),
+        null,
+        'entry memoization filtered by cache'
+      )
+    }).then(() => {
+      return rimraf(CACHE)
+    }).then(() => {
+      return Promise.join(
+        streamGet(false, CACHE, KEY),
+        streamGet(true, CACHE, DIGEST, { hashAlgorithm: ALGO }),
+        (byKey, byDigest) => {
+          t.deepEqual(byKey, {
+            metadata: METADATA,
+            data: CONTENT,
+            hashAlgorithm: ALGO,
+            digest: DIGEST
+          }, 'key fetch fulfilled by memoization cache')
+          t.deepEqual(
+            byDigest.data,
+            CONTENT,
+            'digest fetch fulfilled by memoization cache'
+          )
+        }
+      )
+    }).then(() => {
+      return Promise.join(
+        streamGet(false, CACHE, KEY, {
+          memoize: false
+        }).catch(err => err),
+        streamGet(true, CACHE, DIGEST, {
+          hashAlgorithm: ALGO,
+          memoize: false
+        }).catch(err => err),
+        (keyErr, digestErr) => {
+          t.equal(keyErr.code, 'ENOENT', 'key get memoization bypassed')
+          t.equal(keyErr.code, 'ENOENT', 'digest get memoization bypassed')
+        }
+      )
+    })
+  })
+})
+
+test('get.info uses memoized data', t => {
+  memo.clearMemoized()
+  const ENTRY = {
+    key: KEY,
+    digest: DIGEST,
+    hashAlgorithm: ALGO,
+    time: +(new Date()),
+    metadata: null
+  }
+  memo.put(CACHE, ENTRY, CONTENT)
+  return get.info(CACHE, KEY).then(info => {
+    t.deepEqual(info, ENTRY, 'got the entry from memoization cache')
+  })
+})
+
+test('identical hashes with different algorithms do not conflict')
+test('throw error if something is really wrong with bucket')

--- a/test/index.find.js
+++ b/test/index.find.js
@@ -19,6 +19,7 @@ test('index.find cache hit', function (t) {
   const entry = {
     key: 'whatever',
     digest: 'deadbeef',
+    hashAlgorithm: 'whatnot',
     time: 12345,
     metadata: 'omgsometa'
   }
@@ -100,6 +101,7 @@ test('index.find path-breaking characters', function (t) {
     key: ';;!registry\nhttps://registry.npmjs.org/back \\ slash@Cool™?',
     digest: 'deadbeef',
     time: 12345,
+    hashAlgorithm: 'whatnot',
     metadata: 'omgsometa'
   }
   const idx = {}
@@ -128,6 +130,7 @@ test('index.find extremely long keys', function (t) {
     key: key,
     digest: 'deadbeef',
     time: 12345,
+    hashAlgorithm: 'whatnot',
     metadata: 'woo'
   }
   const idx = {}
@@ -197,6 +200,7 @@ test('index.find hash conflict in same bucket', function (t) {
   const entry = {
     key: 'whatever',
     digest: 'deadbeef',
+    hashAlgorithm: 'whatnot',
     time: 12345,
     metadata: 'yay'
   }

--- a/test/index.insert.js
+++ b/test/index.insert.js
@@ -17,21 +17,32 @@ const index = require('../lib/entry-index')
 const KEY = 'foo'
 const KEYHASH = index._hashKey(KEY)
 const DIGEST = 'deadbeef'
+const ALGO = 'whatnot'
 
 test('basic insertion', function (t) {
   return index.insert(
-    CACHE, KEY, DIGEST
-  ).then(() => {
+    CACHE, KEY, DIGEST, { metadata: 'foo', hashAlgorithm: ALGO }
+  ).then(entry => {
+    t.deepEqual(entry, {
+      key: KEY,
+      digest: DIGEST,
+      hashAlgorithm: ALGO,
+      path: path.join(CACHE, 'content', DIGEST),
+      time: entry.time,
+      metadata: 'foo'
+    }, 'formatted entry returned')
     const bucket = path.join(CACHE, 'index', KEYHASH)
     return fs.readFileAsync(bucket, 'utf8')
   }).then(data => {
     t.equal(data[0], '{', 'first entry starts with a {, not \\n')
     const entry = JSON.parse(data)
     t.ok(entry.time, 'entry has a timestamp')
-    delete entry.time
     t.deepEqual(entry, {
       key: KEY,
-      digest: DIGEST
+      digest: DIGEST,
+      hashAlgorithm: ALGO,
+      time: entry.time,
+      metadata: 'foo'
     }, 'entry matches what was inserted')
   })
 })

--- a/test/index.ls.js
+++ b/test/index.ls.js
@@ -16,12 +16,14 @@ test('basic listing', function (t) {
     'whatever': {
       key: 'whatever',
       digest: 'deadbeef',
+      hashAlgorithm: 'whatnot',
       time: 12345,
       metadata: 'omgsometa'
     },
     'whatnot': {
       key: 'whatnot',
       digest: 'bada55',
+      hashAlgorithm: 'whateva',
       time: 54321,
       metadata: null
     }
@@ -44,12 +46,14 @@ test('separate keys in conflicting buckets', function (t) {
     'whatever': {
       key: 'whatever',
       digest: 'deadbeef',
+      hashAlgorithm: 'whatnot',
       time: 12345,
       metadata: 'omgsometa'
     },
     'whatev': {
       key: 'whatev',
       digest: 'bada55',
+      hashAlgorithm: 'whateva',
       time: 54321,
       metadata: null
     }

--- a/test/memoization.js
+++ b/test/memoization.js
@@ -1,0 +1,69 @@
+'use strict'
+
+const test = require('tap').test
+
+const memo = require('../lib/memoization')
+
+const CACHE = 'mycache'
+const ENTRY = {
+  key: 'foo',
+  digest: 'deadbeef',
+  hashAlgorithm: 'sha512',
+  time: new Date(),
+  metadata: null
+}
+const DATA = 'foobarbaz'
+
+test('memoizes entry and data by key', t => {
+  memo.put(CACHE, ENTRY, DATA)
+  t.deepEqual(memo.clearMemoized(), {
+    [`key:${CACHE}:${ENTRY.key}`]: {
+      entry: ENTRY,
+      data: DATA
+    },
+    [`digest:${CACHE}:${ENTRY.hashAlgorithm}:${ENTRY.digest}`]: DATA
+  }, 'cache has both key and digest entries')
+  t.done()
+})
+
+test('can fetch data by key', t => {
+  memo.put(CACHE, ENTRY, DATA)
+  t.deepEqual(memo.get(CACHE, ENTRY.key), {
+    entry: ENTRY,
+    data: DATA
+  }, 'fetched data correctly')
+  t.deepEqual(
+    memo.get(CACHE + 'meh', ENTRY.key),
+    null,
+    'different caches store different keyspaces'
+  )
+  memo.clearMemoized()
+  t.done()
+})
+
+test('can fetch data by digest', t => {
+  memo.put(CACHE, ENTRY, DATA)
+  t.deepEqual(
+    memo.get.byDigest(CACHE, ENTRY.digest, ENTRY.hashAlgorithm),
+    DATA,
+    'got raw data by digest, without an entry'
+  )
+  memo.clearMemoized()
+  t.done()
+})
+
+test('can clear out the memoization cache', t => {
+  memo.put(CACHE, ENTRY, DATA)
+  memo.clearMemoized()
+  t.deepEqual(
+    memo.get(CACHE, ENTRY.key),
+    null,
+    'entry not there anymore'
+  )
+  t.deepEqual(
+    memo.get.byDigest(ENTRY.digest),
+    null,
+    'digest-based data not there anymore'
+  )
+  t.done()
+})

--- a/test/put.js
+++ b/test/put.js
@@ -1,7 +1,157 @@
 'use strict'
 
-var test = require('tap').test
+const Promise = require('bluebird')
 
-test('stream ends when piped stream finishes')
-test('signals error if error writing to cache')
-test('adds correct entry to index before finishing')
+const crypto = require('crypto')
+const fromString = require('./util/from-string')
+const fs = Promise.promisifyAll(require('fs'))
+const index = require('../lib/entry-index')
+const memo = require('../lib/memoization')
+const path = require('path')
+const pipe = Promise.promisify(require('mississippi').pipe)
+const test = require('tap').test
+const testDir = require('./util/test-dir')(__filename)
+
+const CACHE = path.join(testDir, 'cache')
+const CONTENT = bufferise('foobarbaz')
+const KEY = 'my-test-key'
+const ALGO = 'sha1'
+const DIGEST = crypto.createHash(ALGO).update(CONTENT).digest('hex')
+const METADATA = { foo: 'bar' }
+const contentPath = require('../lib/content/path')
+
+var put = require('../put')
+
+function bufferise (string) {
+  return Buffer.from
+  ? Buffer.from(string, 'utf8')
+  : new Buffer(string, 'utf8')
+}
+
+test('basic bulk insertion', t => {
+  return put(CACHE, KEY, CONTENT).then(digest => {
+    t.equal(digest, DIGEST, 'returned content digest')
+    const dataPath = contentPath(CACHE, digest)
+    return fs.readFileAsync(dataPath)
+  }).then(data => {
+    t.deepEqual(data, CONTENT, 'content was correctly inserted')
+  })
+})
+
+test('basic stream insertion', t => {
+  let foundDigest
+  const src = fromString(CONTENT)
+  const stream = put.stream(CACHE, KEY).on('digest', function (d) {
+    foundDigest = d
+  })
+  return pipe(src, stream).then(() => {
+    t.equal(foundDigest, DIGEST, 'returned digest matches expected')
+    return fs.readFileAsync(contentPath(CACHE, foundDigest))
+  }).then(data => {
+    t.deepEqual(data, CONTENT, 'contents are identical to inserted content')
+  })
+})
+
+test('adds correct entry to index before finishing', t => {
+  return put(CACHE, KEY, CONTENT, {metadata: METADATA}).then(() => {
+    return index.find(CACHE, KEY)
+  }).then(entry => {
+    t.ok(entry, 'got an entry')
+    t.equal(entry.key, KEY, 'entry has the right key')
+    t.equal(entry.digest, DIGEST, 'entry has the right key')
+    t.deepEqual(entry.metadata, METADATA, 'metadata also inserted')
+  })
+})
+
+test('optionally memoizes data on bulk insertion', t => {
+  return put(CACHE, KEY, CONTENT, {
+    metadata: METADATA,
+    hashAlgorithm: ALGO,
+    memoize: true
+  }).then(digest => {
+    t.equal(digest, DIGEST, 'digest returned as usual')
+    return index.find(CACHE, KEY) // index.find is not memoized
+  }).then(entry => {
+    t.deepEqual(memo.get(CACHE, KEY), {
+      data: CONTENT,
+      entry: entry
+    }, 'content inserted into memoization cache by key')
+    t.deepEqual(
+      memo.get.byDigest(CACHE, DIGEST, ALGO),
+      CONTENT,
+      'content inserted into memoization cache by digest'
+    )
+  })
+})
+
+test('optionally memoizes data on stream insertion', t => {
+  let foundDigest
+  const src = fromString(CONTENT)
+  const stream = put.stream(CACHE, KEY, {
+    hashAlgorithm: ALGO,
+    metadata: METADATA,
+    memoize: true
+  }).on('digest', function (d) {
+    foundDigest = d
+  })
+  return pipe(src, stream).then(() => {
+    t.equal(foundDigest, DIGEST, 'digest emitted as usual')
+    return fs.readFileAsync(contentPath(CACHE, foundDigest))
+  }).then(data => {
+    t.deepEqual(data, CONTENT, 'contents are identical to inserted content')
+    return index.find(CACHE, KEY) // index.find is not memoized
+  }).then(entry => {
+    t.deepEqual(memo.get(CACHE, KEY), {
+      data: CONTENT,
+      entry: entry
+    }, 'content inserted into memoization cache by key')
+    t.deepEqual(
+      memo.get.byDigest(CACHE, DIGEST, ALGO),
+      CONTENT,
+      'content inserted into memoization cache by digest'
+    )
+  })
+})
+
+test('signals error if error writing to cache', t => {
+  return Promise.join(
+    put(CACHE, KEY, CONTENT, {
+      size: 2
+    }).then(() => {
+      throw new Error('expected error')
+    }).catch(err => err),
+    pipe(fromString(CONTENT), put.stream(CACHE, KEY, {
+      size: 2
+    })).then(() => {
+      throw new Error('expected error')
+    }).catch(err => err),
+    (bulkErr, streamErr) => {
+      t.equal(bulkErr.code, 'EBADSIZE', 'got error from bulk write')
+      t.equal(streamErr.code, 'EBADSIZE', 'got error from stream write')
+    }
+  )
+})
+
+test('errors if input stream errors', function (t) {
+  let foundDigest
+  const putter = put.stream(CACHE, KEY).on('digest', function (d) {
+    foundDigest = d
+  })
+  const stream = fromString(false)
+  return pipe(
+    stream, putter
+  ).then(() => {
+    throw new Error('expected error')
+  }).catch(err => {
+    t.ok(err, 'got an error')
+    t.ok(!foundDigest, 'no digest returned')
+    t.match(
+      err.message,
+      /Invalid non-string/,
+      'returns the error from input stream'
+    )
+    return fs.readdirAsync(testDir)
+  }).then(files => {
+    t.deepEqual(files, [], 'no files created')
+  })
+})


### PR DESCRIPTION
Fixes: #42 

This adds an in-memory memoization cache to get/put/rm that can be opted into in order to limit disk access.

There's also a bunch of tests and a couple of earmarked fixes included with this blob, as well as an overhauled README.md for the new API.

As #42 says, this is primarily a refactor of code existing in pacote that should make things a lot simpler. Some more patches might end up in this API before 6.0.0 once integration into pacote is underway, but I'd rather get a reasonable thing merged first.