### PR TITLE
fix(hashes): change default hashAlgorithm to sha512

### DIFF
--- a/lib/content/read.js
+++ b/lib/content/read.js
@@ -14,7 +14,7 @@ function readStream (cache, address, opts) {
   opts = opts || {}
   const stream = checksumStream({
     digest: address,
-    algorithm: opts.hashAlgorithm || 'sha1'
+    algorithm: opts.hashAlgorithm || 'sha512'
   })
   const cpath = contentPath(cache, address)
   hasContent(cache, address).then(exists => {

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -113,7 +113,7 @@ function garbageCollect (cache, opts) {
       return Promise.reduce(files, (stats, f) => {
         var fullPath = path.join(contentDir, f)
         if (byDigest[f]) {
-          var algo = opts.hashAlgorithm || 'sha1'
+          var algo = opts.hashAlgorithm || 'sha512'
           return verifyContent(fullPath, algo).then(info => {
             if (!info.valid) {
               stats.collectedCount++

--- a/test/content.read.js
+++ b/test/content.read.js
@@ -15,7 +15,7 @@ const read = require('../lib/content/read')
 
 test('readStream: returns a stream with cache content data', function (t) {
   const CONTENT = 'foobarbaz'
-  const DIGEST = crypto.createHash('sha1').update(CONTENT).digest('hex')
+  const DIGEST = crypto.createHash('sha512').update(CONTENT).digest('hex')
   const dir = {}
   dir[DIGEST] = File(CONTENT)
   const fixture = new Tacks(Dir({
@@ -35,7 +35,7 @@ test('readStream: returns a stream with cache content data', function (t) {
 
 test('readStream: allows hashAlgorithm configuration', function (t) {
   const CONTENT = 'foobarbaz'
-  const HASH = 'sha512'
+  const HASH = 'whirlpool'
   const DIGEST = crypto.createHash(HASH).update(CONTENT).digest('hex')
   const dir = {}
   dir[DIGEST] = File(CONTENT)


### PR DESCRIPTION
sha512 is notably faster than sha256 on 64-bit systems, and sha1
was recently proven to be borked.

Fixes: #44

BREAKING CHANGE:
Default hashAlgorithm changed from sha1 to sha512. If you
rely on the prior setting, pass `opts.hashAlgorithm` in explicitly.