### PR TITLE
fix(index): change index filenames to sha1s of keys

### DIFF
--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -2,6 +2,7 @@
 
 const asyncMap = require('slide/lib/async-map')
 const contentPath = require('./content/path')
+const crypto = require('crypto')
 const fixOwner = require('./util/fix-owner')
 const fs = require('graceful-fs')
 const lockfile = require('lockfile')
@@ -170,8 +171,17 @@ function indexPath (cache, key) {
 
 module.exports._hashKey = hashKey
 function hashKey (key) {
-  // relatively readable key. Conflicts handled by buckets.
-  return key.replace(/[^a-z0-9_-]+/ig, '_').toLowerCase().slice(0, 120)
+  // sha1 conflicts can be generated, but it doesn't matter in this case,
+  // since we intend for there to be regular conflicts anyway. You can have
+  // the entire cache in a single bucket and all that'll do is just make a big
+  // file with a lot of contention, if you can even pull it off in the `key`
+  // string. So whatever. `sha1` is faster and it doesn't trigger the warnings
+  // `md5` tends to (yet?...).
+  return crypto
+  .createHash('sha1')
+  .update(key.toLowerCase()) // lump case-variant keys into same bucket.
+  .digest('hex')
+  .slice(0, 7)
 }
 
 function formatEntry (cache, entry) {

--- a/test/index.insert.js
+++ b/test/index.insert.js
@@ -141,8 +141,8 @@ test('key case-sensitivity', function (t) {
 test('hash conflict in same bucket', function (t) {
   // NOTE - this test will break if `index._hashKey` changes its algorithm.
   //        Adapt to it accordingly.
-  const NEWKEY = KEY + '!'
-  const CONFLICTING = KEY + '!!!'
+  const NEWKEY = KEY.toUpperCase()
+  const CONFLICTING = KEY.toLowerCase()
   return index.insert(
     CACHE, NEWKEY, DIGEST
   ).then(() => (
@@ -157,7 +157,7 @@ test('hash conflict in same bucket', function (t) {
       key: NEWKEY,
       digest: DIGEST
     }, {
-      key: KEY + '!!!',
+      key: CONFLICTING,
       digest: DIGEST
     }], 'multiple entries for conflicting keys in the same bucket')
   })


### PR DESCRIPTION
Fixes: #41 

BREAKING CHANGE: The index format has changed and previous caches are no longer compatible. Existing caches will need to be regenerated.