### PR TITLE
collate index and content directories

### DIFF
--- a/lib/content/path.js
+++ b/lib/content/path.js
@@ -3,6 +3,9 @@
 var path = require('path')
 
 module.exports = contentPath
-function contentPath (cache, address) {
-  return path.join(cache, 'content', address)
+function contentPath (cache, address, hashAlgorithm) {
+  address = address && address.toLowerCase()
+  hashAlgorithm = hashAlgorithm ? hashAlgorithm.toLowerCase() : 'sha512'
+  return path.join(
+    cache, 'content', hashAlgorithm, address.slice(0, 2), address)
 }

--- a/lib/content/put-stream.js
+++ b/lib/content/put-stream.js
@@ -91,7 +91,7 @@ function pipeToTmp (inputStream, cache, tmpTarget, opts, errCheck) {
   let digest
   const hashStream = checksumStream({
     digest: opts.digest,
-    algorithm: opts.hashAlgorithm,
+    algorithm: opts.hashAlgorithm || 'sha512',
     size: opts.size
   }).on('digest', d => {
     digest = d
@@ -128,7 +128,7 @@ function pipeToTmp (inputStream, cache, tmpTarget, opts, errCheck) {
 
 function moveToDestination (tmpTarget, cache, digest, opts, errCheck) {
   errCheck()
-  const destination = contentPath(cache, digest)
+  const destination = contentPath(cache, digest, opts.hashAlgorithm)
   const destDir = path.dirname(destination)
 
   return fixOwner.mkdirfix(

--- a/lib/content/read.js
+++ b/lib/content/read.js
@@ -16,8 +16,8 @@ function readStream (cache, address, opts) {
     digest: address,
     algorithm: opts.hashAlgorithm || 'sha512'
   })
-  const cpath = contentPath(cache, address)
-  hasContent(cache, address).then(exists => {
+  const cpath = contentPath(cache, address, opts.hashAlgorithm || 'sha512')
+  hasContent(cache, address, opts.hashAlgorithm).then(exists => {
     if (!exists) {
       const err = new Error('content not found')
       err.code = 'ENOENT'
@@ -34,10 +34,10 @@ function readStream (cache, address, opts) {
 }
 
 module.exports.hasContent = hasContent
-function hasContent (cache, address, cb) {
+function hasContent (cache, address, algorithm) {
   if (!address) { return Promise.resolve(false) }
   return fs.lstatAsync(
-    contentPath(cache, address)
+    contentPath(cache, address, algorithm || 'sha512')
   ).then(() => true).catch(err => {
     if (err && err.code === 'ENOENT') {
       return Promise.resolve(false)

--- a/lib/content/rm.js
+++ b/lib/content/rm.js
@@ -6,6 +6,8 @@ var contentPath = require('./path')
 var rimraf = Promise.promisify(require('rimraf'))
 
 module.exports = rm
-function rm (cache, address) {
-  return rimraf(contentPath(cache, address))
+function rm (cache, address, algorithm) {
+  address = address.toLowerCase()
+  algorithm = algorithm && algorithm.toLowerCase()
+  return rimraf(contentPath(cache, address, algorithm || 'sha512'))
 }

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -15,7 +15,7 @@ const through = require('mississippi').through
 module.exports.insert = insert
 function insert (cache, key, digest, opts) {
   opts = opts || {}
-  const bucket = indexPath(cache, key)
+  const bucket = bucketPath(cache, key)
   const lock = bucket + '.lock'
   return fixOwner.mkdirfix(
     path.dirname(bucket), opts.uid, opts.gid
@@ -74,7 +74,7 @@ function insert (cache, key, digest, opts) {
 
 module.exports.find = find
 function find (cache, key) {
-  const bucket = indexPath(cache, key)
+  const bucket = bucketPath(cache, key)
   const stream = fs.createReadStream(bucket)
   let ret
   return Promise.fromNode(cb => {
@@ -105,37 +105,49 @@ function del (cache, key) {
 
 module.exports.lsStream = lsStream
 function lsStream (cache) {
-  const indexPath = path.join(cache, 'index')
+  const indexDir = path.join(cache, 'index')
   const stream = through.obj()
-  fs.readdir(indexPath, function (err, files) {
+  fs.readdir(indexDir, function (err, buckets) {
     if (err && err.code === 'ENOENT') {
       return stream.end()
     } else if (err) {
       return stream.emit('error', err)
     } else {
-      asyncMap(files, function (f, cb) {
-        fs.readFile(path.join(indexPath, f), 'utf8', function (err, data) {
-          if (err) { return cb(err) }
-          const entries = {}
-          data.split('\n').forEach(function (entry) {
-            let parsed
-            try {
-              parsed = JSON.parse(entry)
-            } catch (e) {
-            }
-            // NOTE - it's possible for an entry to be
-            //        incomplete/corrupt. So we just skip it.
-            //        See comment on `insert()` for deets.
-            if (parsed) {
-              entries[parsed.key] = formatEntry(cache, parsed)
-            }
-          })
-          Object.keys(entries).forEach(function (k) {
-            stream.write(entries[k])
-          })
-          cb()
+      asyncMap(buckets, (bucket, cb) => {
+        fs.readdir(path.join(indexDir, bucket), (err, files) => {
+          if (err && err.code === 'ENOENT') {
+            return cb()
+          } else if (err) {
+            return cb(err)
+          } else {
+            asyncMap(files, function (f, cb) {
+              fs.readFile(path.join(indexDir, bucket, f), 'utf8', function (err, data) {
+                if (err) { return cb(err) }
+                const entries = {}
+                data.split('\n').forEach(function (entry) {
+                  let parsed
+                  try {
+                    parsed = JSON.parse(entry)
+                  } catch (e) {
+                  }
+                  // NOTE - it's possible for an entry to be
+                  //        incomplete/corrupt. So we just skip it.
+                  //        See comment on `insert()` for deets.
+                  if (parsed) {
+                    entries[parsed.key] = formatEntry(cache, parsed)
+                  }
+                })
+                Object.keys(entries).forEach(function (k) {
+                  stream.write(entries[k])
+                })
+                cb()
+              })
+            }, function (err) {
+              cb(err)
+            })
+          }
         })
-      }, function (err) {
+      }, err => {
         if (err) { stream.emit('error') }
         stream.end()
       })
@@ -165,8 +177,10 @@ function notFoundError (cache, key) {
   return err
 }
 
-function indexPath (cache, key) {
-  return path.join(cache, 'index', hashKey(key))
+module.exports._bucketPath = bucketPath
+function bucketPath (cache, key) {
+  const hashed = hashKey(key)
+  return path.join(cache, 'index', hashed.slice(0, 2), hashed)
 }
 
 module.exports._hashKey = hashKey

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -203,7 +203,7 @@ function formatEntry (cache, entry) {
     key: entry.key,
     digest: entry.digest,
     hashAlgorithm: entry.hashAlgorithm,
-    path: contentPath(cache, entry.digest),
+    path: contentPath(cache, entry.digest, entry.hashAlgorithm),
     time: entry.time,
     metadata: entry.metadata
   }

--- a/test/content.put-stream.chownr.js
+++ b/test/content.put-stream.chownr.js
@@ -31,13 +31,14 @@ test('allows setting a custom uid for cache contents on write', {
   t.plan(7)
   pipe(fromString(CONTENT), putStream(CACHE, {
     uid: NEWUID,
-    gid: NEWGID
+    gid: NEWGID,
+    hashAlgorithm: 'sha1'
   }), function (err) {
     if (err) { throw err }
     var expectedPaths = [
       CACHE, // this includes cache/tmp
       path.join(CACHE, 'content'),
-      path.join(CACHE, 'content', DIGEST)
+      path.join(CACHE, 'content', 'sha1', DIGEST.slice(0, 2), DIGEST)
     ]
     t.deepEqual(
       updatedPaths.sort(),

--- a/test/content.put-stream.js
+++ b/test/content.put-stream.js
@@ -18,7 +18,8 @@ const putStream = require('../lib/content/put-stream')
 
 test('basic put', function (t) {
   const CONTENT = 'foobarbaz'
-  const DIGEST = crypto.createHash('sha1').update(CONTENT).digest('hex')
+  // Default is sha512
+  const DIGEST = crypto.createHash('sha512').update(CONTENT).digest('hex')
   let foundDigest
   const src = fromString(CONTENT)
   const stream = putStream(CACHE).on('digest', function (d) {
@@ -42,7 +43,7 @@ test('basic put', function (t) {
 
 test('checks input digest doesn\'t match data', function (t) {
   const CONTENT = 'foobarbaz'
-  const DIGEST = crypto.createHash('sha1').update(CONTENT).digest('hex')
+  const DIGEST = crypto.createHash('sha512').update(CONTENT).digest('hex')
   t.plan(5)
   let foundDigest1
   let foundDigest2
@@ -107,7 +108,7 @@ test('errors if input size does not match expected', function (t) {
 
 test('does not overwrite content if already on disk', function (t) {
   const CONTENT = 'foobarbaz'
-  const DIGEST = crypto.createHash('sha1').update(CONTENT).digest('hex')
+  const DIGEST = crypto.createHash('sha512').update(CONTENT).digest('hex')
   const contentDir = {}
   contentDir[DIGEST] = File('nope')
   const fixture = new Tacks(Dir({
@@ -163,7 +164,7 @@ test('errors if input stream errors', function (t) {
 
 test('exits normally if file already open', function (t) {
   const CONTENT = 'foobarbaz'
-  const DIGEST = crypto.createHash('sha1').update(CONTENT).digest('hex')
+  const DIGEST = crypto.createHash('sha512').update(CONTENT).digest('hex')
   const PATH = path.join(CACHE, 'content', DIGEST)
   const contentDir = {}
   contentDir[DIGEST] = File(CONTENT)

--- a/test/content.rm.js
+++ b/test/content.rm.js
@@ -17,7 +17,9 @@ const rm = require('../lib/content/rm')
 test('removes a content entry', function (t) {
   const fixture = new Tacks(Dir({
     'content': Dir({
-      'deadbeef': File('')
+      'de': Dir({
+        'deadbeef': File('')
+      })
     })
   }))
   fixture.create(CACHE)

--- a/test/get.js
+++ b/test/get.js
@@ -59,7 +59,11 @@ function streamGet (byDigest) {
 test('basic bulk get', t => {
   const fixture = new Tacks(Dir({
     'content': Dir({
-      [DIGEST]: File(CONTENT)
+      [ALGO]: Dir({
+        [DIGEST.slice(0, 2)]: Dir({
+          [DIGEST]: File(CONTENT)
+        })
+      })
     })
   }))
   fixture.create(CACHE)
@@ -85,7 +89,11 @@ test('basic bulk get', t => {
 test('basic stream get', t => {
   const fixture = new Tacks(Dir({
     'content': Dir({
-      [DIGEST]: File(CONTENT)
+      [ALGO]: Dir({
+        [DIGEST.slice(0, 2)]: Dir({
+          [DIGEST]: File(CONTENT)
+        })
+      })
     })
   }))
   fixture.create(CACHE)
@@ -141,7 +149,11 @@ test('memoizes data on bulk read', t => {
   memo.clearMemoized()
   const fixture = new Tacks(Dir({
     'content': Dir({
-      [DIGEST]: File(CONTENT)
+      [ALGO]: Dir({
+        [DIGEST.slice(0, 2)]: Dir({
+          [DIGEST]: File(CONTENT)
+        })
+      })
     })
   }))
   fixture.create(CACHE)
@@ -191,7 +203,11 @@ test('memoizes data on stream read', t => {
   memo.clearMemoized()
   const fixture = new Tacks(Dir({
     'content': Dir({
-      [DIGEST]: File(CONTENT)
+      [ALGO]: Dir({
+        [DIGEST.slice(0, 2)]: Dir({
+          [DIGEST]: File(CONTENT)
+        })
+      })
     })
   }))
   fixture.create(CACHE)

--- a/test/index.find.js
+++ b/test/index.find.js
@@ -33,7 +33,11 @@ test('index.find cache hit', function (t) {
     CACHE, entry.key
   ).then(info => {
     t.ok(info, 'cache hit')
-    t.equal(info.path, contentPath(CACHE, entry.digest), 'path added to info')
+    t.equal(
+      info.path,
+      contentPath(CACHE, entry.digest, entry.hashAlgorithm),
+      'path added to info'
+    )
     delete info.path
     t.deepEqual(info, entry, 'rest of info matches entry on disk')
   })

--- a/test/index.insert.js
+++ b/test/index.insert.js
@@ -16,6 +16,7 @@ const index = require('../lib/entry-index')
 
 const KEY = 'foo'
 const KEYHASH = index._hashKey(KEY)
+const BUCKET = index._bucketPath(CACHE, KEY)
 const DIGEST = 'deadbeef'
 const ALGO = 'whatnot'
 
@@ -31,8 +32,7 @@ test('basic insertion', function (t) {
       time: entry.time,
       metadata: 'foo'
     }, 'formatted entry returned')
-    const bucket = path.join(CACHE, 'index', KEYHASH)
-    return fs.readFileAsync(bucket, 'utf8')
+    return fs.readFileAsync(BUCKET, 'utf8')
   }).then(data => {
     t.equal(data[0], '{', 'first entry starts with a {, not \\n')
     const entry = JSON.parse(data)
@@ -53,8 +53,7 @@ test('inserts additional entries into existing key', function (t) {
   ).then(() => (
     index.insert(CACHE, KEY, DIGEST, {metadata: 2})
   )).then(() => {
-    const bucket = path.join(CACHE, 'index', KEYHASH)
-    return fs.readFileAsync(bucket, 'utf8')
+    return fs.readFileAsync(BUCKET, 'utf8')
   }).then(data => {
     const entries = data.split('\n').map(JSON.parse)
     entries.forEach(function (e) { delete e.time })
@@ -84,8 +83,7 @@ test('separates entries even if one is corrupted', function (t) {
   return index.insert(
     CACHE, KEY, DIGEST
   ).then(() => {
-    const bucket = path.join(CACHE, 'index', KEYHASH)
-    return fs.readFileAsync(bucket, 'utf8')
+    return fs.readFileAsync(BUCKET, 'utf8')
   }).then(data => {
     const entry = JSON.parse(data.split('\n')[4])
     delete entry.time
@@ -101,8 +99,7 @@ test('optional arbitrary metadata', function (t) {
   return index.insert(
     CACHE, KEY, DIGEST, { metadata: metadata }
   ).then(() => {
-    const bucket = path.join(CACHE, 'index', KEYHASH)
-    return fs.readFileAsync(bucket, 'utf8')
+    return fs.readFileAsync(BUCKET, 'utf8')
   }).then(data => {
     const entry = JSON.parse(data)
     delete entry.time
@@ -119,8 +116,7 @@ test('key case-sensitivity', function (t) {
     index.insert(CACHE, KEY, DIGEST),
     index.insert(CACHE, KEY.toUpperCase(), DIGEST)
   ).then(() => {
-    const bucket = path.join(CACHE, 'index', KEYHASH)
-    return fs.readFileAsync(bucket, 'utf8')
+    return fs.readFileAsync(BUCKET, 'utf8')
   }).then(data => {
     const entries = data.split('\n').map(JSON.parse).sort(e => (
       e.key === KEY
@@ -148,7 +144,7 @@ test('hash conflict in same bucket', function (t) {
   ).then(() => (
     index.insert(CACHE, CONFLICTING, DIGEST)
   )).then(() => {
-    const bucket = path.join(CACHE, 'index', index._hashKey(NEWKEY))
+    const bucket = index._bucketPath(CACHE, NEWKEY)
     return fs.readFileAsync(bucket, 'utf8')
   }).then(data => {
     const entries = data.split('\n').map(JSON.parse)
@@ -165,11 +161,10 @@ test('hash conflict in same bucket', function (t) {
 
 test('path-breaking characters', function (t) {
   const newKey = ';;!registry\nhttps://registry.npmjs.org/back \\ slash@Cool™?'
-  const newHash = index._hashKey(newKey)
   return index.insert(
     CACHE, newKey, DIGEST
   ).then(() => {
-    const bucket = path.join(CACHE, 'index', newHash)
+    const bucket = index._bucketPath(CACHE, newKey)
     return fs.readFileAsync(bucket, 'utf8')
   }).then(data => {
     const entry = JSON.parse(data)
@@ -186,11 +181,10 @@ test('extremely long keys', function (t) {
   for (let i = 0; i < 10000; i++) {
     newKey += i
   }
-  const newHash = index._hashKey(newKey)
   return index.insert(
     CACHE, newKey, DIGEST
   ).then(() => {
-    const bucket = path.join(CACHE, 'index', newHash)
+    const bucket = index._bucketPath(CACHE, newKey)
     return fs.readFileAsync(bucket, 'utf8')
   }).then(data => {
     const entry = JSON.parse(data)

--- a/test/index.insert.js
+++ b/test/index.insert.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const CacheIndex = require('./util/cache-index')
+const contentPath = require('../lib/content/path')
 const fs = require('fs')
 const path = require('path')
 const Promise = require('bluebird')
@@ -15,7 +16,6 @@ const Dir = Tacks.Dir
 const index = require('../lib/entry-index')
 
 const KEY = 'foo'
-const KEYHASH = index._hashKey(KEY)
 const BUCKET = index._bucketPath(CACHE, KEY)
 const DIGEST = 'deadbeef'
 const ALGO = 'whatnot'
@@ -28,7 +28,7 @@ test('basic insertion', function (t) {
       key: KEY,
       digest: DIGEST,
       hashAlgorithm: ALGO,
-      path: path.join(CACHE, 'content', DIGEST),
+      path: contentPath(CACHE, DIGEST, ALGO),
       time: entry.time,
       metadata: 'foo'
     }, 'formatted entry returned')

--- a/test/index.ls.js
+++ b/test/index.ls.js
@@ -32,9 +32,11 @@ test('basic listing', function (t) {
     'index': CacheIndex(contents)
   }))
   contents.whatever.path =
-    contentPath(CACHE, contents.whatever.digest)
+    contentPath(
+      CACHE, contents.whatever.digest, contents.whatever.hashAlgorithm)
   contents.whatnot.path =
-    contentPath(CACHE, contents.whatnot.digest)
+    contentPath(
+      CACHE, contents.whatnot.digest, contents.whatnot.hashAlgorithm)
   fixture.create(CACHE)
   return index.ls(CACHE).then(listing => {
     t.deepEqual(listing, contents, 'index contents correct')
@@ -65,9 +67,11 @@ test('separate keys in conflicting buckets', function (t) {
     })
   }))
   contents.whatever.path =
-    contentPath(CACHE, contents.whatever.digest)
+    contentPath(
+      CACHE, contents.whatever.digest, contents.whatever.hashAlgorithm)
   contents.whatev.path =
-    contentPath(CACHE, contents.whatev.digest)
+    contentPath(
+      CACHE, contents.whatev.digest, contents.whatev.hashAlgorithm)
   fixture.create(CACHE)
   return index.ls(CACHE).then(listing => {
     t.deepEqual(listing, contents, 'index contents correct')

--- a/test/put.js
+++ b/test/put.js
@@ -15,7 +15,7 @@ const testDir = require('./util/test-dir')(__filename)
 const CACHE = path.join(testDir, 'cache')
 const CONTENT = bufferise('foobarbaz')
 const KEY = 'my-test-key'
-const ALGO = 'sha1'
+const ALGO = 'sha512'
 const DIGEST = crypto.createHash(ALGO).update(CONTENT).digest('hex')
 const METADATA = { foo: 'bar' }
 const contentPath = require('../lib/content/path')
@@ -31,7 +31,7 @@ function bufferise (string) {
 test('basic bulk insertion', t => {
   return put(CACHE, KEY, CONTENT).then(digest => {
     t.equal(digest, DIGEST, 'returned content digest')
-    const dataPath = contentPath(CACHE, digest)
+    const dataPath = contentPath(CACHE, digest, ALGO)
     return fs.readFileAsync(dataPath)
   }).then(data => {
     t.deepEqual(data, CONTENT, 'content was correctly inserted')

--- a/test/util/cache-index.js
+++ b/test/util/cache-index.js
@@ -16,6 +16,7 @@ function CacheIndex (entries) {
   Object.keys(entries).forEach(function (k) {
     var lines = entries[k]
     var hashed = hashKey(k)
+    var prefix = hashed.slice(0, 2)
     var serialised
     if (typeof lines === 'string') {
       serialised = lines
@@ -25,12 +26,17 @@ function CacheIndex (entries) {
       }
       serialised = lines.map(JSON.stringify).join('\n')
     }
-    index[hashed] = index[hashed]
-    ? [index[hashed], serialised].join('\n')
+    index[prefix] = index[prefix] || {}
+    index[prefix][hashed] = index[prefix][hashed]
+    ? [index[prefix][hashed], serialised].join('\n')
     : serialised
   })
-  Object.keys(index).forEach(function (k) {
-    index[k] = File(index[k])
+  Object.keys(index).forEach(function (prefix) {
+    var files = {}
+    Object.keys(index[prefix]).forEach(key => {
+      files[key] = File(index[prefix][key])
+    })
+    index[prefix] = Dir(files)
   })
   return Dir(index)
 }


### PR DESCRIPTION
Fixes: #14 

Here we are! This patch changes the format of both the index and the content directories such that they're prefixed by the first two characters of their respective hashes on their filenames.

Furthermore, for content directories, there's an additional layer where we use the name of the hash to make sure there's no hash conflicts even if two hash algorithms SOMEHOW manage to actually conflict with each other. And tbh, even with that possibility? It's kinda nice to be able to look in your content dir and get an idea of which of those corresponds to which hashAlgorithm. `cacache.verify`, for example, can just use that instead of trying to guess which one was used.

### NOTE
This breaks the `verify()` command, but that should be done as a separate PR because it really does need better, dedicated tests. #3 is the issue to track for this particular problem. I don't feel bad because `verify()` was only ever a hacked-together prototype and needs to be wrapped up right.