### PR TITLE
feat(size): handle content size info

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ cacache.ls(cachePath).then(console.log)
     integrity: 'sha512-BaSe64/EnCoDED+HAsh=='
     path: '.testcache/content/deadbeef', // joined with `cachePath`
     time: 12345698490,
+    size: 4023948,
     metadata: {
       name: 'blah',
       version: '1.2.3',
@@ -131,7 +132,8 @@ cacache.ls(cachePath).then(console.log)
     key: 'other-thing',
     integrity: 'sha1-ANothER+hasH=',
     path: '.testcache/content/bada55',
-    time: 11992309289
+    time: 11992309289,
+    size: 111112
   }
 }
 ```
@@ -153,6 +155,7 @@ cacache.ls.stream(cachePath).on('data', console.log)
   integrity: 'sha512-BaSe64HaSh',
   path: '.testcache/content/deadbeef', // joined with `cachePath`
   time: 12345698490,
+  size: 13423,
   metadata: {
     name: 'blah',
     version: '1.2.3',
@@ -164,7 +167,8 @@ cacache.ls.stream(cachePath).on('data', console.log)
   key: 'other-thing',
   integrity: 'whirlpool-WoWSoMuchSupport',
   path: '.testcache/content/bada55',
-  time: 11992309289
+  time: 11992309289,
+  size: 498023984029
 }
 
 {
@@ -208,7 +212,8 @@ cache.get(cachePath, 'my-thing').then(console.log)
     thingName: 'my'
   },
   integrity: 'sha512-BaSe64HaSh',
-  data: Buffer#<deadbeef>
+  data: Buffer#<deadbeef>,
+  size: 9320
 }
 
 // Look up by digest
@@ -280,6 +285,7 @@ cacache.get.info(cachePath, 'my-thing').then(console.log)
   integrity: 'sha256-MUSTVERIFY+ALL/THINGS=='
   path: '.testcache/content/deadbeef',
   time: 12345698490,
+  size: 849234,
   metadata: {
     name: 'blah',
     version: '1.2.3',
@@ -356,6 +362,8 @@ digest](#integrity)
 for inserted data. Can use any algorithm listed in `crypto.getHashes()` or
 `'omakase'`/`'お任せします'` to pick a random hash algorithm on each insertion. You
 may also use any anagram of `'modnar'` to use this feature.
+
+Has no effect if `opts.integrity` is present.
 
 ##### `opts.uid`/`opts.gid`
 

--- a/get.js
+++ b/get.js
@@ -26,7 +26,8 @@ function getData (byDigest, cache, key, opts) {
     return BB.resolve(byDigest ? memoized : {
       metadata: memoized.entry.metadata,
       data: memoized.data,
-      integrity: memoized.entry.integrity
+      integrity: memoized.entry.integrity,
+      size: memoized.entry.size
     })
   }
   return (
@@ -41,6 +42,7 @@ function getData (byDigest, cache, key, opts) {
     }).then(data => byDigest ? data : {
       metadata: entry.metadata,
       data: data,
+      size: entry.size,
       integrity: entry.integrity
     }).then(res => {
       if (opts.memoize && byDigest) {
@@ -62,6 +64,7 @@ function getStream (cache, key, opts) {
     stream.on('newListener', function (ev, cb) {
       ev === 'metadata' && cb(memoized.entry.metadata)
       ev === 'integrity' && cb(memoized.entry.integrity)
+      ev === 'size' && cb(memoized.entry.size)
     })
     stream.write(memoized.data, () => stream.end())
     return stream
@@ -87,11 +90,14 @@ function getStream (cache, key, opts) {
     } else {
       memoStream = through()
     }
+    opts.size = opts.size == null ? entry.size : opts.size
     stream.emit('metadata', entry.metadata)
     stream.emit('integrity', entry.integrity)
+    stream.emit('size', entry.size)
     stream.on('newListener', function (ev, cb) {
       ev === 'metadata' && cb(entry.metadata)
       ev === 'integrity' && cb(entry.integrity)
+      ev === 'size' && cb(entry.size)
     })
     pipe(
       read.readStream(cache, entry.integrity, opts),

--- a/lib/content/write.js
+++ b/lib/content/write.js
@@ -37,7 +37,7 @@ function write (cache, data, opts) {
     ).then(() => (
       moveToDestination(tmp, cache, sri, opts)
     ))
-  )).then(() => sri)
+  )).then(() => ({integrity: sri, size: data.length}))
 }
 
 module.exports.stream = writeStream
@@ -62,8 +62,9 @@ function writeStream (cache, opts) {
         e.code = 'ENODATA'
         return ret.emit('error', e)
       }
-      allDone.then(sri => {
-        sri && ret.emit('integrity', sri)
+      allDone.then(res => {
+        res.integrity && ret.emit('integrity', res.integrity)
+        res.size !== null && ret.emit('size', res.size)
         cb()
       }, e => {
         ret.emit('error', e)
@@ -81,30 +82,33 @@ function handleContent (inputStream, cache, opts, errCheck) {
     errCheck()
     return pipeToTmp(
       inputStream, cache, tmp.target, opts, errCheck
-    ).then(sri => {
+    ).then(res => {
       return moveToDestination(
-        tmp, cache, sri, opts, errCheck
-      ).then(() => sri)
+        tmp, cache, res.integrity, opts, errCheck
+      ).then(() => res)
     })
   })
 }
 
 function pipeToTmp (inputStream, cache, tmpTarget, opts, errCheck) {
   return BB.resolve().then(() => {
-    let sri
+    let integrity
+    let size
     const hashStream = ssri.integrityStream({
       integrity: opts.integrity,
       algorithms: opts.algorithms,
       size: opts.size
     }).on('integrity', s => {
-      sri = s
+      integrity = s
+    }).on('size', s => {
+      size = s
     })
     const outStream = fs.createWriteStream(tmpTarget, {
       flags: 'wx'
     })
     errCheck()
     return pipe(inputStream, hashStream, outStream).then(() => {
-      return sri
+      return {integrity, size}
     }, err => {
       return rimraf(tmpTarget).then(() => { throw err })
     })

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -36,6 +36,7 @@ function insert (cache, key, integrity, opts) {
     key,
     integrity: integrity && ssri.stringify(integrity),
     time: Date.now(),
+    size: opts.size,
     metadata: opts.metadata
   }
   return fixOwner.mkdirfix(
@@ -206,6 +207,7 @@ function formatEntry (cache, entry) {
     key: entry.key,
     integrity: entry.integrity,
     path: contentPath(cache, entry.integrity),
+    size: entry.size,
     time: entry.time,
     metadata: entry.metadata
   }

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -9,7 +9,6 @@ const fs = require('graceful-fs')
 const glob = BB.promisify(require('glob'))
 const index = require('./entry-index')
 const path = require('path')
-const pipe = BB.promisify(require('mississippi').pipe)
 const rimraf = BB.promisify(require('rimraf'))
 const ssri = require('ssri')
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "7.0.5",
   "cache-version": {
     "content": "2",
-    "index": "4"
+    "index": "5"
   },
   "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
   "main": "index.js",

--- a/test/index.find.js
+++ b/test/index.find.js
@@ -11,6 +11,7 @@ const testDir = require('./util/test-dir')(__filename)
 BB.promisifyAll(fs)
 
 const CACHE = path.join(testDir, 'cache')
+const SIZE = 999
 const contentPath = require('../lib/content/path')
 const index = require('../lib/entry-index')
 
@@ -19,7 +20,8 @@ test('index.find cache hit', function (t) {
     key: 'whatever',
     integrity: 'whatnot-deadbeef',
     time: 12345,
-    metadata: 'omgsometa'
+    metadata: 'omgsometa',
+    size: 5
   }
   const fixture = new Tacks(CacheIndex({
     'whatever': entry
@@ -68,12 +70,14 @@ test('index.find key case-sensitivity', function (t) {
     'jsonstream': {
       key: 'jsonstream',
       integrity: 'sha1-lowercase',
-      time: 54321
+      time: 54321,
+      size: SIZE
     },
     'JSONStream': {
       key: 'JSONStream',
       integrity: 'sha1-capitalised',
-      time: 12345
+      time: 12345,
+      size: SIZE
     }
   }))
   fixture.create(CACHE)
@@ -97,7 +101,8 @@ test('index.find path-breaking characters', function (t) {
     key: ';;!registry\nhttps://registry.npmjs.org/back \\ slash@Cool™?',
     integrity: 'sha1-deadbeef',
     time: 12345,
-    metadata: 'omgsometa'
+    metadata: 'omgsometa',
+    size: 9
   }
   const fixture = new Tacks(CacheIndex({
     [entry.key]: entry
@@ -123,7 +128,8 @@ test('index.find extremely long keys', function (t) {
     key: key,
     integrity: 'sha1-deadbeef',
     time: 12345,
-    metadata: 'woo'
+    metadata: 'woo',
+    size: 10
   }
   const fixture = new Tacks(CacheIndex({
     [entry.key]: entry
@@ -190,7 +196,8 @@ test('index.find hash conflict in same bucket', function (t) {
     key: 'whatever',
     integrity: 'sha1-deadbeef',
     time: 12345,
-    metadata: 'yay'
+    metadata: 'yay',
+    size: 8
   }
   const fixture = new Tacks(CacheIndex({
     'whatever': [

--- a/test/ls.js
+++ b/test/ls.js
@@ -20,13 +20,15 @@ test('basic listing', function (t) {
       key: 'whatever',
       integrity: 'sha512-deadbeef',
       time: 12345,
-      metadata: 'omgsometa'
+      metadata: 'omgsometa',
+      size: 234234
     },
     'whatnot': {
       key: 'whatnot',
       integrity: 'sha512-bada55',
       time: 54321,
-      metadata: null
+      metadata: null,
+      size: 425345345
     }
   }
   const fixture = new Tacks(CacheIndex(contents))
@@ -57,13 +59,15 @@ test('separate keys in conflicting buckets', function (t) {
       key: 'whatever',
       integrity: 'sha512-deadbeef',
       time: 12345,
-      metadata: 'omgsometa'
+      metadata: 'omgsometa',
+      size: 5
     },
     'whatev': {
       key: 'whatev',
       integrity: 'sha512-bada55',
       time: 54321,
-      metadata: null
+      metadata: null,
+      size: 99234234
     }
   }
   const fixture = new Tacks(CacheIndex({

--- a/test/util/cache-index.js
+++ b/test/util/cache-index.js
@@ -15,11 +15,10 @@ const File = Tacks.File
 //
 // The returned object is for use with Tacks
 module.exports = CacheIndex
-function CacheIndex (entries, hashAlgorithm) {
-  hashAlgorithm = hashAlgorithm || 'sha512'
+function CacheIndex (entries) {
   var tree = Dir({})
   Object.keys(entries).forEach(function (k) {
-    const bpath = bucketPath('', k, hashAlgorithm)
+    const bpath = bucketPath('', k)
     const parts = bpath.split(path.sep)
     let lines = entries[k]
     let serialised


### PR DESCRIPTION
This is kind of a rough sketch of keeping size information in the cache index. Even though we already verify size if it's passed in, this can make error reporting a little nicer, as well as improve on the sorts of things `verify()` can do (and report!).

Having size information is super handy for being able to determine whether to, say, load the entire contents of something into memory vs using streams, figuring out whether to memoize them, etc. Both make-fetch-happen and cacache itself are able to take advantage of this.

This bumps the index version to 5, too, but as usual, that's not a breaking change.

I mentioned before that this could help with SHAttered, but I didn't realize both of them were the exact same size :< -- there's a separate mitigation for that to prevent it from affecting the cache if both are inserted.