### PR TITLE
Add version info to entry and content dirs

### DIFF
--- a/lib/content/path.js
+++ b/lib/content/path.js
@@ -1,11 +1,21 @@
 'use strict'
 
+var contentVer = require('../../package.json')['cache-version'].content
 var path = require('path')
 
+// Current format of content file path:
+//
+// ~/.my-cache/content-v1/sha512/ba/bada55deadbeefc0ffee
+//
 module.exports = contentPath
 function contentPath (cache, address, hashAlgorithm) {
   address = address && address.toLowerCase()
   hashAlgorithm = hashAlgorithm ? hashAlgorithm.toLowerCase() : 'sha512'
   return path.join(
-    cache, 'content', hashAlgorithm, address.slice(0, 2), address)
+    cache,
+    `content-v${contentVer}`,
+    hashAlgorithm,
+    address.slice(0, 2),
+    address
+  )
 }

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -12,6 +12,8 @@ const Promise = require('bluebird')
 const split = require('split')
 const through = require('mississippi').through
 
+const indexV = require('../package.json')['cache-version'].index
+
 module.exports.insert = insert
 function insert (cache, key, digest, opts) {
   opts = opts || {}
@@ -105,7 +107,7 @@ function del (cache, key) {
 
 module.exports.lsStream = lsStream
 function lsStream (cache) {
-  const indexDir = path.join(cache, 'index')
+  const indexDir = bucketDir(cache)
   const stream = through.obj()
   fs.readdir(indexDir, function (err, buckets) {
     if (err && err.code === 'ENOENT') {
@@ -177,10 +179,14 @@ function notFoundError (cache, key) {
   return err
 }
 
+function bucketDir (cache) {
+  return path.join(cache, `index-v${indexV}`)
+}
+
 module.exports._bucketPath = bucketPath
 function bucketPath (cache, key) {
   const hashed = hashKey(key)
-  return path.join(cache, 'index', hashed.slice(0, 2), hashed)
+  return path.join(bucketDir(cache), hashed.slice(0, 2), hashed)
 }
 
 module.exports._hashKey = hashKey

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "cacache",
   "version": "5.0.3",
+  "cache-version": {
+    "content": "1",
+    "index": "1"
+  },
   "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
   "main": "index.js",
   "files": [

--- a/test/content.put-stream.chownr.js
+++ b/test/content.put-stream.chownr.js
@@ -10,6 +10,8 @@ var testDir = require('./util/test-dir')(__filename)
 
 var CACHE = path.join(testDir, 'cache')
 
+var contentPath = require('../lib/content/path')
+
 test('allows setting a custom uid for cache contents on write', {
   skip: !process.getuid // On a platform that doesn't support uid/gid
 }, function (t) {
@@ -35,10 +37,11 @@ test('allows setting a custom uid for cache contents on write', {
     hashAlgorithm: 'sha1'
   }), function (err) {
     if (err) { throw err }
+    const cpath = contentPath(CACHE, DIGEST, 'sha1')
     var expectedPaths = [
-      CACHE, // this includes cache/tmp
-      path.join(CACHE, 'content'),
-      path.join(CACHE, 'content', 'sha1', DIGEST.slice(0, 2), DIGEST)
+      CACHE,
+      path.join(CACHE, path.relative(CACHE, cpath).split(path.sep)[0]),
+      cpath
     ]
     t.deepEqual(
       updatedPaths.sort(),

--- a/test/get.js
+++ b/test/get.js
@@ -12,8 +12,7 @@ const Tacks = require('tacks')
 const test = require('tap').test
 const testDir = require('./util/test-dir')(__filename)
 
-const Dir = Tacks.Dir
-const File = Tacks.File
+const CacheContent = require('./util/cache-content')
 
 const CACHE = path.join(testDir, 'cache')
 const CONTENT = bufferise('foobarbaz')
@@ -57,15 +56,9 @@ function streamGet (byDigest) {
 }
 
 test('basic bulk get', t => {
-  const fixture = new Tacks(Dir({
-    'content': Dir({
-      [ALGO]: Dir({
-        [DIGEST.slice(0, 2)]: Dir({
-          [DIGEST]: File(CONTENT)
-        })
-      })
-    })
-  }))
+  const fixture = new Tacks(CacheContent({
+    [DIGEST]: CONTENT
+  }, ALGO))
   fixture.create(CACHE)
   return index.insert(CACHE, KEY, DIGEST, {
     metadata: METADATA,
@@ -87,15 +80,9 @@ test('basic bulk get', t => {
 })
 
 test('basic stream get', t => {
-  const fixture = new Tacks(Dir({
-    'content': Dir({
-      [ALGO]: Dir({
-        [DIGEST.slice(0, 2)]: Dir({
-          [DIGEST]: File(CONTENT)
-        })
-      })
-    })
-  }))
+  const fixture = new Tacks(CacheContent({
+    [DIGEST]: CONTENT
+  }, ALGO))
   fixture.create(CACHE)
   return index.insert(CACHE, KEY, DIGEST, {
     metadata: METADATA,
@@ -147,15 +134,9 @@ test('get.info index entry lookup', t => {
 
 test('memoizes data on bulk read', t => {
   memo.clearMemoized()
-  const fixture = new Tacks(Dir({
-    'content': Dir({
-      [ALGO]: Dir({
-        [DIGEST.slice(0, 2)]: Dir({
-          [DIGEST]: File(CONTENT)
-        })
-      })
-    })
-  }))
+  const fixture = new Tacks(CacheContent({
+    [DIGEST]: CONTENT
+  }, ALGO))
   fixture.create(CACHE)
   return index.insert(CACHE, KEY, DIGEST, {
     metadata: METADATA,
@@ -201,15 +182,9 @@ test('memoizes data on bulk read', t => {
 
 test('memoizes data on stream read', t => {
   memo.clearMemoized()
-  const fixture = new Tacks(Dir({
-    'content': Dir({
-      [ALGO]: Dir({
-        [DIGEST.slice(0, 2)]: Dir({
-          [DIGEST]: File(CONTENT)
-        })
-      })
-    })
-  }))
+  const fixture = new Tacks(CacheContent({
+    [DIGEST]: CONTENT
+  }, ALGO))
   fixture.create(CACHE)
   return index.insert(CACHE, KEY, DIGEST, {
     metadata: METADATA,

--- a/test/index.find.js
+++ b/test/index.find.js
@@ -23,10 +23,8 @@ test('index.find cache hit', function (t) {
     time: 12345,
     metadata: 'omgsometa'
   }
-  const fixture = new Tacks(Dir({
-    'index': CacheIndex({
-      'whatever': entry
-    })
+  const fixture = new Tacks(CacheIndex({
+    'whatever': entry
   }))
   fixture.create(CACHE)
   return index.find(
@@ -44,11 +42,9 @@ test('index.find cache hit', function (t) {
 })
 
 test('index.find cache miss', function (t) {
-  const fixture = new Tacks(Dir({
-    'index': CacheIndex({
-      'foo': {key: 'foo'},
-      'w/e': {key: 'w/e'}
-    })
+  const fixture = new Tacks(CacheIndex({
+    'foo': {key: 'foo'},
+    'w/e': {key: 'w/e'}
   }))
   fixture.create(CACHE)
   return index.find(
@@ -70,19 +66,17 @@ test('index.find no cache', function (t) {
 })
 
 test('index.find key case-sensitivity', function (t) {
-  const fixture = new Tacks(Dir({
-    'index': CacheIndex({
-      'jsonstream': {
-        key: 'jsonstream',
-        digest: 'lowercase',
-        time: 54321
-      },
-      'JSONStream': {
-        key: 'JSONStream',
-        digest: 'capitalised',
-        time: 12345
-      }
-    })
+  const fixture = new Tacks(CacheIndex({
+    'jsonstream': {
+      key: 'jsonstream',
+      digest: 'lowercase',
+      time: 54321
+    },
+    'JSONStream': {
+      key: 'JSONStream',
+      digest: 'capitalised',
+      time: 12345
+    }
   }))
   fixture.create(CACHE)
   return Promise.join(
@@ -108,10 +102,8 @@ test('index.find path-breaking characters', function (t) {
     hashAlgorithm: 'whatnot',
     metadata: 'omgsometa'
   }
-  const idx = {}
-  idx[entry.key] = entry
-  const fixture = new Tacks(Dir({
-    'index': CacheIndex(idx)
+  const fixture = new Tacks(CacheIndex({
+    [entry.key]: entry
   }))
   fixture.create(CACHE)
   return index.find(CACHE, entry.key).then(info => {
@@ -137,10 +129,8 @@ test('index.find extremely long keys', function (t) {
     hashAlgorithm: 'whatnot',
     metadata: 'woo'
   }
-  const idx = {}
-  idx[entry.key] = entry
-  const fixture = new Tacks(Dir({
-    'index': CacheIndex(idx)
+  const fixture = new Tacks(CacheIndex({
+    [entry.key]: entry
   }))
   fixture.create(CACHE)
   return index.find(CACHE, entry.key).then(info => {
@@ -156,13 +146,11 @@ test('index.find extremely long keys', function (t) {
 
 test('index.find multiple index entries for key', function (t) {
   const key = 'whatever'
-  const fixture = new Tacks(Dir({
-    'index': CacheIndex({
-      'whatever': [
-        { key: key, digest: 'deadbeef', time: 54321 },
-        { key: key, digest: 'bada55', time: 12345 }
-      ]
-    })
+  const fixture = new Tacks(CacheIndex({
+    'whatever': [
+      { key: key, digest: 'deadbeef', time: 54321 },
+      { key: key, digest: 'bada55', time: 12345 }
+    ]
   }))
   fixture.create(CACHE)
   return index.find(CACHE, key).then(info => {
@@ -183,14 +171,12 @@ test('index.find garbled data in index file', function (t) {
   // to the process crashing). In this case, the corrupt entry
   // will simply be skipped.
   const key = 'whatever'
-  const fixture = new Tacks(Dir({
-    'index': CacheIndex({
-      'whatever': '\n' + JSON.stringify({
-        key: key,
-        digest: 'deadbeef',
-        time: 54321
-      }) + '\n{"key": "' + key + '"\noway'
-    })
+  const fixture = new Tacks(CacheIndex({
+    'whatever': '\n' + JSON.stringify({
+      key: key,
+      digest: 'deadbeef',
+      time: 54321
+    }) + '\n{"key": "' + key + '"\noway'
   }))
   fixture.create(CACHE)
   return index.find(CACHE, key).then(info => {
@@ -208,14 +194,12 @@ test('index.find hash conflict in same bucket', function (t) {
     time: 12345,
     metadata: 'yay'
   }
-  const fixture = new Tacks(Dir({
-    'index': CacheIndex({
-      'whatever': [
-        { key: 'ohnoes', digest: 'welp!' },
-        entry,
-        { key: 'nope', digest: 'bada55' }
-      ]
-    })
+  const fixture = new Tacks(CacheIndex({
+    'whatever': [
+      { key: 'ohnoes', digest: 'welp!' },
+      entry,
+      { key: 'nope', digest: 'bada55' }
+    ]
   }))
   fixture.create(CACHE)
   return index.find(CACHE, entry.key).then(info => {

--- a/test/index.insert.js
+++ b/test/index.insert.js
@@ -70,14 +70,12 @@ test('inserts additional entries into existing key', function (t) {
 })
 
 test('separates entries even if one is corrupted', function (t) {
-  const fixture = new Tacks(Dir({
-    'index': CacheIndex({
-      'foo': '\n' + JSON.stringify({
-        key: KEY,
-        digest: 'meh',
-        time: 54321
-      }) + '\n{"key": "' + KEY + '"\noway'
-    })
+  const fixture = new Tacks(CacheIndex({
+    'foo': '\n' + JSON.stringify({
+      key: KEY,
+      digest: 'meh',
+      time: 54321
+    }) + '\n{"key": "' + KEY + '"\noway'
   }))
   fixture.create(CACHE)
   return index.insert(

--- a/test/index.ls.js
+++ b/test/index.ls.js
@@ -8,7 +8,6 @@ const testDir = require('./util/test-dir')(__filename)
 
 const CACHE = path.join(testDir, 'cache')
 const contentPath = require('../lib/content/path')
-const Dir = Tacks.Dir
 const index = require('../lib/entry-index')
 
 test('basic listing', function (t) {
@@ -28,9 +27,7 @@ test('basic listing', function (t) {
       metadata: null
     }
   }
-  const fixture = new Tacks(Dir({
-    'index': CacheIndex(contents)
-  }))
+  const fixture = new Tacks(CacheIndex(contents))
   contents.whatever.path =
     contentPath(
       CACHE, contents.whatever.digest, contents.whatever.hashAlgorithm)
@@ -60,11 +57,9 @@ test('separate keys in conflicting buckets', function (t) {
       metadata: null
     }
   }
-  const fixture = new Tacks(Dir({
-    'index': CacheIndex({
-      // put both in the same bucket
-      'whatever': [contents.whatever, contents.whatev]
-    })
+  const fixture = new Tacks(CacheIndex({
+    // put both in the same bucket
+    'whatever': [contents.whatever, contents.whatev]
   }))
   contents.whatever.path =
     contentPath(

--- a/test/util/cache-content.js
+++ b/test/util/cache-content.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const contentPath = require('../../lib/content/path')
+const path = require('path')
+const Tacks = require('tacks')
+
+const Dir = Tacks.Dir
+const File = Tacks.File
+
+module.exports = CacheContent
+function CacheContent (entries, hashAlgorithm) {
+  hashAlgorithm = hashAlgorithm || 'sha512'
+  var tree = Dir({})
+  Object.keys(entries).forEach(function (k) {
+    const cpath = contentPath('', k, hashAlgorithm)
+    const content = entries[k]
+    const parts = cpath.split(path.sep)
+    insertContent(tree, parts, content)
+  })
+  return tree
+}
+
+function insertContent (tree, pathTo, content) {
+  const key = pathTo[0]
+  if (pathTo.length <= 1) {
+    tree.contents[key] = File(content)
+  } else {
+    tree.contents[key] = tree.contents[key] || Dir({})
+    insertContent(tree.contents[key], pathTo.slice(1), content)
+  }
+}

--- a/test/util/cache-index.js
+++ b/test/util/cache-index.js
@@ -1,23 +1,25 @@
 'use strict'
 
-var hashKey = require('../../lib/entry-index')._hashKey
-var Tacks = require('tacks')
+const bucketPath = require('../../lib/entry-index')._bucketPath
+const path = require('path')
+const Tacks = require('tacks')
 
-var Dir = Tacks.Dir
-var File = Tacks.File
+const Dir = Tacks.Dir
+const File = Tacks.File
 
 // Creates a simulated index using the chained lookup structure, from
 // an unhashed version of the index (basically `cacache.ls`).
 //
 // The returned object is for use with Tacks
 module.exports = CacheIndex
-function CacheIndex (entries) {
-  var index = {}
+function CacheIndex (entries, hashAlgorithm) {
+  hashAlgorithm = hashAlgorithm || 'sha512'
+  var tree = Dir({})
   Object.keys(entries).forEach(function (k) {
-    var lines = entries[k]
-    var hashed = hashKey(k)
-    var prefix = hashed.slice(0, 2)
-    var serialised
+    const bpath = bucketPath('', k, hashAlgorithm)
+    const parts = bpath.split(path.sep)
+    let lines = entries[k]
+    let serialised
     if (typeof lines === 'string') {
       serialised = lines
     } else {
@@ -26,17 +28,24 @@ function CacheIndex (entries) {
       }
       serialised = lines.map(JSON.stringify).join('\n')
     }
-    index[prefix] = index[prefix] || {}
-    index[prefix][hashed] = index[prefix][hashed]
-    ? [index[prefix][hashed], serialised].join('\n')
-    : serialised
+    insertContent(tree, parts, serialised)
   })
-  Object.keys(index).forEach(function (prefix) {
-    var files = {}
-    Object.keys(index[prefix]).forEach(key => {
-      files[key] = File(index[prefix][key])
-    })
-    index[prefix] = Dir(files)
-  })
-  return Dir(index)
+  return tree
+}
+
+function insertContent (tree, pathTo, content) {
+  const key = pathTo[0]
+  if (pathTo.length <= 1) {
+    if (tree.contents[key]) {
+      tree.contents[key] = File([
+        tree.contents[key].contents,
+        content
+      ].join('\n'))
+    } else {
+      tree.contents[key] = File(content)
+    }
+  } else {
+    tree.contents[key] = tree.contents[key] || Dir({})
+    insertContent(tree.contents[key], pathTo.slice(1), content)
+  }
 }


### PR DESCRIPTION
Fixes: #50 

This should allow us to write migrations in the future. This will both prevent conflicts should someone bump their cacache version into something with an incompatible cache, as well as allow automatic migrations getting added to cacache itself, I guess provided that the core invariants are left intact (that cacache is generally a key/value store that allows content addressing and metadata).