### PR TITLE
Throw Caution to the Wind or: How I Learned To Stop Worrying And Love The Race

### DIFF
--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -29,8 +29,16 @@ function insert (cache, key, digest, opts) {
       time: +(new Date()),
       metadata: opts.metadata
     }
+    const stringified = JSON.stringify(entry)
+    // NOTE - Cleverness ahoy!
+    //
+    // This works because it's tremendously unlikely for an entry to corrupt
+    // another while still preserving the string length of the JSON in
+    // question. So, we just slap the length in there and verify it on read.
+    //
+    // Thanks to @isaacs for the whiteboarding session that ended up with this.
     return appendFileAsync(
-      bucket, '\n' + JSON.stringify(entry)
+      bucket, `\n${stringified.length}\t${stringified}`
     ).then(() => entry)
   }).then(entry => (
     fixOwner.chownr(bucket, opts.uid, opts.gid).then(() => (
@@ -46,10 +54,16 @@ function find (cache, key) {
   let ret
   return Promise.fromNode(cb => {
     pipe(stream, split('\n', null, {trailing: true}).on('data', function (l) {
+      const pieces = l.split('\t')
+      if (!pieces[1] || pieces[1].length !== parseInt(pieces[0], 10)) {
+        // Length is no good! Corruption ahoy!
+        return
+      }
       let obj
       try {
-        obj = JSON.parse(l)
+        obj = JSON.parse(pieces[1])
       } catch (e) {
+        // Entry is corrupted!
         return
       }
       if (obj && (obj.key === key)) {
@@ -92,9 +106,14 @@ function lsStream (cache) {
                 if (err) { return cb(err) }
                 const entries = {}
                 data.split('\n').slice(1).forEach(function (entry) {
+                  const pieces = entry.split('\t')
+                  if (pieces[1].length !== parseInt(pieces[0], 10)) {
+                    // Length is no good! Corruption ahoy!
+                    return
+                  }
                   let parsed
                   try {
-                    parsed = JSON.parse(entry)
+                    parsed = JSON.parse(pieces[1])
                   } catch (e) {
                   }
                   // NOTE - it's possible for an entry to be

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -5,7 +5,6 @@ const contentPath = require('./content/path')
 const crypto = require('crypto')
 const fixOwner = require('./util/fix-owner')
 const fs = require('graceful-fs')
-const lockfile = require('lockfile')
 const path = require('path')
 const pipe = require('mississippi').pipe
 const Promise = require('bluebird')
@@ -14,64 +13,30 @@ const through = require('mississippi').through
 
 const indexV = require('../package.json')['cache-version'].index
 
+const appendFileAsync = Promise.promisify(fs.appendFile)
+
 module.exports.insert = insert
 function insert (cache, key, digest, opts) {
   opts = opts || {}
   const bucket = bucketPath(cache, key)
-  const lock = bucket + '.lock'
   return fixOwner.mkdirfix(
     path.dirname(bucket), opts.uid, opts.gid
-  ).then(() => (
-    Promise.fromNode(_cb => {
-      const cb = (err, entry) => {
-        lockfile.unlock(lock, er => {
-          _cb(err || er, entry)
-        })
-      }
-      lockfile.lock(lock, {
-        stale: 60000,
-        retries: 10,
-        wait: 10000
-      }, function (err) {
-        if (err) { return _cb(err) }
-        fs.stat(bucket, function (err, existing) {
-          if (err && err.code !== 'ENOENT' && err.code !== 'EPERM') {
-            return cb(err)
-          }
-          const entry = {
-            key: key,
-            digest: digest,
-            hashAlgorithm: opts.hashAlgorithm,
-            time: +(new Date()),
-            metadata: opts.metadata
-          }
-          // Because of the way these entries work,
-          // the index is safe from fs.appendFile stopping
-          // mid-write so long as newlines are *prepended*
-          //
-          // That is, if a write fails, it will be ignored
-          // by `find`, and the next successful one will be
-          // used.
-          //
-          // This should be -very rare-, since `fs.appendFile`
-          // will often be atomic on most platforms unless
-          // very large metadata has been included, but caches
-          // like this one tend to last a long time. :)
-          // Most corrupted reads are likely to be from attempting
-          // to read the index while it's being written to --
-          // which is safe, but not guaranteed to be atomic.
-          const e = (existing ? '\n' : '') + JSON.stringify(entry)
-          fs.appendFile(bucket, e, function (err) {
-            cb(err, entry)
-          })
-        })
-      })
-    })
-  )).then(entry => {
-    return fixOwner.chownr(bucket, opts.uid, opts.gid).then(() => {
-      return formatEntry(cache, entry)
-    })
-  })
+  ).then(() => {
+    const entry = {
+      key: key,
+      digest: digest,
+      hashAlgorithm: opts.hashAlgorithm,
+      time: +(new Date()),
+      metadata: opts.metadata
+    }
+    return appendFileAsync(
+      bucket, '\n' + JSON.stringify(entry)
+    ).then(() => entry)
+  }).then(entry => (
+    fixOwner.chownr(bucket, opts.uid, opts.gid).then(() => (
+      formatEntry(cache, entry)
+    ))
+  ))
 }
 
 module.exports.find = find
@@ -126,7 +91,7 @@ function lsStream (cache) {
               fs.readFile(path.join(indexDir, bucket, f), 'utf8', function (err, data) {
                 if (err) { return cb(err) }
                 const entries = {}
-                data.split('\n').forEach(function (entry) {
+                data.split('\n').slice(1).forEach(function (entry) {
                   let parsed
                   try {
                     parsed = JSON.parse(entry)
@@ -186,30 +151,15 @@ function bucketDir (cache) {
 module.exports._bucketPath = bucketPath
 function bucketPath (cache, key) {
   const hashed = hashKey(key)
-  return path.join(bucketDir(cache), hashed.slice(0, 2), hashed)
+  return path.join(bucketDir(cache), hashed.slice(0, 2), hashed.slice(2))
 }
 
 module.exports._hashKey = hashKey
 function hashKey (key) {
-  // NOTE (SECURITY)
-  //
-  // `sha1` conflicts can be generated, but it doesn't matter in this case,
-  // since we intend for there to be regular conflicts anyway. You can have
-  // the entire cache in a single bucket and all that'll do is just make a big
-  // file with a lot of contention, if you can even pull it off in the `key`
-  // string. So whatever. `sha1` is faster and it doesn't trigger the warnings
-  // `md5` tends to (yet?...).
-  //
-  // Not to mention, that in the case of pacote/npm, the amount of control
-  // anyone would have over this key is so minimal that it's incredibly
-  // unlikely that they could intentionally generate a large number of
-  // conflicts just with a package key such that they'd do anything resembling
-  // a hash flood DOS.
   return crypto
-  .createHash('sha1')
-  .update(key.toLowerCase()) // lump case-variant keys into same bucket.
+  .createHash('sha256')
+  .update(key)
   .digest('hex')
-  .slice(0, 7)
 }
 
 function formatEntry (cache, entry) {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "chownr": "^1.0.1",
     "dezalgo": "^1.0.3",
     "graceful-fs": "^4.1.10",
-    "lockfile": "^1.0.2",
     "mississippi": "^1.2.0",
     "mkdirp": "^0.5.1",
     "once": "^1.4.0",

--- a/test/index.find.js
+++ b/test/index.find.js
@@ -171,12 +171,15 @@ test('index.find garbled data in index file', function (t) {
   // to the process crashing). In this case, the corrupt entry
   // will simply be skipped.
   const key = 'whatever'
+  const stringified = JSON.stringify({
+    key: key,
+    digest: 'deadbeef',
+    time: 54321
+  })
   const fixture = new Tacks(CacheIndex({
-    'whatever': '\n' + JSON.stringify({
-      key: key,
-      digest: 'deadbeef',
-      time: 54321
-    }) + '\n{"key": "' + key + '"\noway'
+    'whatever': '\n' +
+    `${stringified.length}\t${stringified}` +
+    '\n{"key": "' + key + '"\noway'
   }))
   fixture.create(CACHE)
   return index.find(CACHE, key).then(info => {

--- a/test/util/cache-index.js
+++ b/test/util/cache-index.js
@@ -26,7 +26,7 @@ function CacheIndex (entries, hashAlgorithm) {
       if (typeof lines.length !== 'number') {
         lines = [lines]
       }
-      serialised = lines.map(JSON.stringify).join('\n')
+      serialised = '\n' + lines.map(JSON.stringify).join('\n')
     }
     insertContent(tree, parts, serialised)
   })

--- a/test/util/cache-index.js
+++ b/test/util/cache-index.js
@@ -26,7 +26,10 @@ function CacheIndex (entries, hashAlgorithm) {
       if (typeof lines.length !== 'number') {
         lines = [lines]
       }
-      serialised = '\n' + lines.map(JSON.stringify).join('\n')
+      serialised = '\n' + lines.map(line => {
+        const stringified = JSON.stringify(line)
+        return `${stringified.length}\t${stringified}`
+      }).join('\n')
     }
     insertContent(tree, parts, serialised)
   })


### PR DESCRIPTION
Fixes: #21 

This is a pretty significant stunt: it gets rid of file locking on index entry writes. This means that two different `fs.appendFile` calls could be happening to the exact same file at the same time, even in parallel on different processes.

My hypothesis is that this is totally fine, and the invariants it prevents are things cacache never actually promised. That is, concurrent writes will simply invalidate each other, and cacache does not promise the cache will always contain all data: it only guarantees that *if* the data is there, it is the *correct* data. As such, it's totally fine for some entries to corrupt and invalidate each other. Not to mention that the "expensive" operations involve the actual content, which does not invalidate so easily.

I'd still like some eyeballs on this. It still needs some tests. There's also some questions about this:

* are my assumptions correct that the only effect is mutual invalidation? Is there any case where two inserts can sync up perfectly to create one full valid entry with bizarre frankenstein data? What about 3 inserts? n inserts?
* by reducing bucket conflicts, the index can now have as many (or more) files in it than content/. Is this too many files? How many of them would there really be if the entire 4million+ entry npm registry were inserted into the cache?
* is a length check sufficient? Should it be a checksum instead?
* am I missing something here?
* Let's put it into npm, run a big install, and see how it goes, even if we have cacache-side tests.

Who needs lockfiles anyway? 😏 

### Benchmarks

Operation | Before | After | Change
---|---|---|---
`put()` | 1.686ms | 1.548ms | -8%
`put.stream()` | 1.364ms | 1.229ms | **-10%**
`index.insert()` | 0.5058ms | 0.3291ms | **-34%**
`index.find() hit` | 0.2518ms | 0.2603ms | *+3%*
`index.find() miss` | 0.1102ms | 0.1074ms | *-2.5%*