### PR TITLE
Add benchmark suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "benchmark": "^2.1.3",
+    "format-number": "^2.0.2",
     "glob": "^7.1.1",
     "nyc": "^10.0.0",
     "require-inject": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "unique-filename": "^1.1.0"
   },
   "devDependencies": {
+    "benchmark": "^2.1.3",
     "glob": "^7.1.1",
     "nyc": "^10.0.0",
     "require-inject": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lib"
   ],
   "scripts": {
+    "benchmarks": "node test/benchmarks",
     "preversion": "npm t",
     "postversion": "npm publish && git push --follow-tags",
     "pretest": "standard lib test *.js",

--- a/test/benchmarks/index.find.js
+++ b/test/benchmarks/index.find.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const CacheIndex = require('../util/cache-index')
+const Tacks = require('tacks')
+
+const index = require('../../lib/entry-index')
+
+module.exports = (suite, CACHE) => {
+  suite.add('index.find cache hit', {
+    defer: true,
+    fn (deferred) {
+      index.find(
+        CACHE, this.entry.key
+      ).then(
+        () => deferred.resolve(),
+        err => deferred.reject(err)
+      )
+    },
+    onStart () {
+      const entry = {
+        key: 'whatever',
+        digest: 'deadbeef',
+        hashAlgorithm: 'whatnot',
+        time: 12345,
+        metadata: 'omgsometa'
+      }
+      const fixture = new Tacks(CacheIndex({
+        'whatever': entry
+      }))
+      fixture.create(CACHE)
+      this.fixture = fixture
+      this.entry = entry
+    }
+  })
+
+  suite.add('index.find cache miss', {
+    defer: true,
+    fn (deferred) {
+      index.find(
+        CACHE, 'whatever'
+      ).then(
+        () => deferred.resolve(),
+        err => deferred.reject(err)
+      )
+    },
+    onStart () {
+      const fixture = new Tacks(CacheIndex({
+        'foo': {key: 'foo'},
+        'w/e': {key: 'w/e'}
+      }))
+      fixture.create(CACHE)
+      this.fixture = fixture
+    }
+  })
+}

--- a/test/benchmarks/index.insert.js
+++ b/test/benchmarks/index.insert.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const KEY = 'foo'
+const DIGEST = 'deadbeef'
+const ALGO = 'whatnot'
+
+const index = require('../../lib/entry-index')
+
+module.exports = (suite, CACHE) => {
+  suite.add('index.insert() different files', {
+    defer: true,
+    fn (deferred) {
+      index.insert(CACHE, KEY + this.count, DIGEST, {
+        metadata: 'foo',
+        hashAlgorithm: ALGO
+      }).then(
+        () => deferred.resolve(),
+        err => deferred.reject(err)
+      )
+    }
+  })
+  suite.add('index.insert() same file', {
+    defer: true,
+    fn (deferred) {
+      index.insert(CACHE, KEY, DIGEST, {
+        metadata: 'foo',
+        hashAlgorithm: ALGO
+      }).then(
+        () => deferred.resolve(),
+        err => deferred.reject(err)
+      )
+    }
+  })
+}

--- a/test/benchmarks/index.js
+++ b/test/benchmarks/index.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const Benchmark = require('benchmark')
+const fmtms = require('format-number')({round: 4})
+const fs = require('fs')
+const path = require('path')
+const rimraf = require('rimraf')
+
+const CACHE = path.join(__dirname, '../', 'cache', 'benchmarks')
+
+const suite = new Benchmark.Suite({
+  onStart () {
+    console.log('--- cacache performance benchmarks ---')
+  },
+  onCycle (event) {
+    const bench = event.target
+    console.log(`--- ${bench.name} ---`)
+    console.log(`Avg: ${fmtms(bench.stats.mean * 1000)}ms`)
+    console.log(`SEM: ${fmtms(bench.stats.sem * 1000)}ms`)
+    console.log(`RME: ${fmtms(bench.stats.rme)}%`)
+    console.log(`Total: ${bench.times.elapsed}s`)
+    console.log('--------------------------------------')
+    rimraf.sync(CACHE)
+  },
+  onComplete () {
+    console.log('--------------------------------------')
+  }
+})
+
+fs.readdir(__dirname, (err, files) => {
+  if (err) { throw err }
+  files.forEach(f => {
+    if (path.extname(f) === '.js' && f !== 'index.js') {
+      require('./' + f)(suite, path.join(CACHE, path.basename(f, '.js')))
+    }
+  })
+  suite.run({async: true})
+})

--- a/test/benchmarks/put.js
+++ b/test/benchmarks/put.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const Promise = require('bluebird')
+
+const finished = Promise.promisify(require('mississippi').finished)
+
+let buf = []
+for (let i = 0; i < Math.pow(2, 8); i++) {
+  buf.push(Buffer.alloc ? Buffer.alloc(8, i) : new Buffer(8))
+}
+
+const CONTENT = Buffer.concat(buf, buf.length * 8)
+const arr = []
+for (let i = 0; i < 100; i++) {
+  arr.push(CONTENT)
+}
+const BIGCONTENT = Buffer.concat(arr, CONTENT.length * 1000)
+const KEY = 'my-test-key'
+
+var put = require('../../put')
+
+module.exports = (suite, CACHE) => {
+  suite.add('cacache.put()', {
+    defer: true,
+    fn (deferred) {
+      put(
+        CACHE, KEY + this.count, CONTENT + this.count
+      ).then(
+        () => deferred.resolve(),
+        err => deferred.reject(err)
+      )
+    }
+  })
+
+  suite.add(`cacache.put.stream() ${CONTENT.length} bytes`, {
+    defer: true,
+    fn (deferred) {
+      const stream = put.stream(CACHE, KEY + this.count)
+      finished(
+        stream
+      ).then(
+        () => deferred.resolve(),
+        err => deferred.reject(err)
+      )
+      stream.write(CONTENT + this.count)
+      stream.end()
+    }
+  })
+
+  suite.add(`cacache.put.stream() ${BIGCONTENT.length} bytes`, {
+    defer: true,
+    minSamples: 30,
+    maxTime: 30,
+    fn (deferred) {
+      const stream = put.stream(CACHE, KEY + this.count)
+      finished(
+        stream
+      ).then(
+        () => deferred.resolve(),
+        err => deferred.reject(err)
+      )
+      stream.write(BIGCONTENT + this.count)
+      stream.end()
+    }
+  })
+}


### PR DESCRIPTION
This PR adds a benchmark suite that can be used to compare cacache performance as we tweak things here and there and find us some corner cases. It uses [`benchmark.js`](https://npm.im/benchmark) as a bench runner and just vomits some basic reports to terminal.