### PR TITLE
Speed up bulk get/read

### DIFF
--- a/lib/content/read.js
+++ b/lib/content/read.js
@@ -4,11 +4,30 @@ const Promise = require('bluebird')
 
 const checksumStream = require('checksum-stream')
 const contentPath = require('./path')
+const crypto = require('crypto')
 const fs = require('graceful-fs')
 const pipeline = require('mississippi').pipeline
 
 Promise.promisifyAll(fs)
 
+module.exports = read
+function read (cache, address, opts) {
+  opts = opts || {}
+  const algo = opts.hashAlgorithm || 'sha512'
+  const cpath = contentPath(cache, address, algo)
+  return fs.readFileAsync(cpath, null).then(data => {
+    const digest = crypto.createHash(algo).update(data).digest('hex')
+    if (typeof opts.size === 'number' && opts.size !== data.length) {
+      throw sizeError(opts.size, data.length)
+    } else if (digest !== address) {
+      throw checksumError(address, digest)
+    } else {
+      return data
+    }
+  })
+}
+
+module.exports.stream = readStream
 module.exports.readStream = readStream
 function readStream (cache, address, opts) {
   opts = opts || {}
@@ -36,4 +55,20 @@ function hasContent (cache, address, algorithm) {
       throw err
     }
   })
+}
+
+function sizeError (expected, found) {
+  var err = new Error('stream data size mismatch')
+  err.expected = expected
+  err.found = found
+  err.code = 'EBADSIZE'
+  return err
+}
+
+function checksumError (expected, found) {
+  var err = new Error('checksum failed')
+  err.code = 'EBADCHECKSUM'
+  err.expected = expected
+  err.found = found
+  return err
 }

--- a/test/benchmarks/content.read.js
+++ b/test/benchmarks/content.read.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const CacheContent = require('../util/cache-content')
+const crypto = require('crypto')
+const Tacks = require('tacks')
+
+const read = require('../../lib/content/read')
+
+let buf = []
+for (let i = 0; i < Math.pow(2, 8); i++) {
+  buf.push(Buffer.alloc ? Buffer.alloc(8, i) : new Buffer(8))
+}
+
+const CONTENT = Buffer.concat(buf, buf.length * 8)
+const DIGEST = crypto.createHash('sha512').update(CONTENT).digest('hex')
+
+const arr = []
+for (let i = 0; i < 100; i++) {
+  arr.push(CONTENT)
+}
+const BIGCONTENT = Buffer.concat(arr, CONTENT.length * 1000)
+const BIGDIGEST = crypto.createHash('sha512').update(BIGCONTENT).digest('hex')
+
+module.exports = (suite, CACHE) => {
+  suite.add('content.read()', {
+    defer: true,
+    setup () {
+      const fixture = new Tacks(CacheContent({
+        [DIGEST]: CONTENT
+      }))
+      fixture.create(CACHE)
+    },
+    fn (deferred) {
+      read(
+        CACHE, DIGEST
+      ).then(
+        () => deferred.resolve(),
+        err => deferred.reject(err)
+      )
+    }
+  })
+
+  suite.add('content.read.stream() small data', {
+    defer: true,
+    setup () {
+      const fixture = new Tacks(CacheContent({
+        [DIGEST]: CONTENT
+      }))
+      fixture.create(CACHE)
+    },
+    fn (deferred) {
+      const stream = read.stream(CACHE, DIGEST)
+      stream.on('data', () => {})
+      stream.on('error', err => deferred.reject(err))
+      stream.on('end', () => {
+        deferred.resolve()
+      })
+    }
+  })
+
+  suite.add('content.read.stream() big data', {
+    defer: true,
+    setup () {
+      const fixture = new Tacks(CacheContent({
+        [BIGDIGEST]: BIGCONTENT
+      }))
+      fixture.create(CACHE)
+    },
+    fn (deferred) {
+      const stream = read.stream(CACHE, BIGDIGEST)
+      stream.on('data', () => {})
+      stream.on('error', err => deferred.reject(err))
+      stream.on('end', () => {
+        deferred.resolve()
+      })
+    }
+  })
+}

--- a/test/benchmarks/get.js
+++ b/test/benchmarks/get.js
@@ -1,0 +1,97 @@
+'use strict'
+
+const CacheContent = require('../util/cache-content')
+const crypto = require('crypto')
+const memo = require('../../lib/memoization')
+const Tacks = require('tacks')
+
+const get = require('../../get')
+
+let buf = []
+for (let i = 0; i < Math.pow(2, 8); i++) {
+  buf.push(Buffer.alloc ? Buffer.alloc(8, i) : new Buffer(8))
+}
+
+const CONTENT = Buffer.concat(buf, buf.length * 8)
+const DIGEST = crypto.createHash('sha512').update(CONTENT).digest('hex')
+
+const arr = []
+for (let i = 0; i < 100; i++) {
+  arr.push(CONTENT)
+}
+const BIGCONTENT = Buffer.concat(arr, CONTENT.length * 1000)
+const BIGDIGEST = crypto.createHash('sha512').update(BIGCONTENT).digest('hex')
+
+module.exports = (suite, CACHE) => {
+  suite.add('get.byDigest()', {
+    defer: true,
+    setup () {
+      const fixture = new Tacks(CacheContent({
+        [DIGEST]: CONTENT
+      }))
+      fixture.create(CACHE)
+    },
+    fn (deferred) {
+      get.byDigest(
+        CACHE, DIGEST
+      ).then(
+        () => deferred.resolve(),
+        err => deferred.reject(err)
+      )
+    }
+  })
+
+  suite.add('get.byDigest() memoized', {
+    defer: true,
+    setup () {
+      memo.put.byDigest(CACHE, DIGEST, 'sha512', CONTENT)
+    },
+    fn (deferred) {
+      get.byDigest(
+        CACHE, DIGEST
+      ).then(
+        () => deferred.resolve(),
+        err => deferred.reject(err)
+      )
+    },
+    tearDown () {
+      memo.clearMemoized()
+    }
+  })
+
+  suite.add('get.stream.byDigest() small data', {
+    defer: true,
+    setup () {
+      const fixture = new Tacks(CacheContent({
+        [DIGEST]: CONTENT
+      }))
+      fixture.create(CACHE)
+    },
+    fn (deferred) {
+      const stream = get.stream.byDigest(CACHE, DIGEST, { memoize: false })
+      stream.on('data', () => {})
+      stream.on('error', err => deferred.reject(err))
+      stream.on('end', () => {
+        deferred.resolve()
+      })
+    }
+  })
+
+  suite.add('get.stream() big data', {
+    defer: true,
+    setup () {
+      const fixture = new Tacks(CacheContent({
+        [BIGDIGEST]: BIGCONTENT
+      }))
+      fixture.create(CACHE)
+    },
+    fn (deferred) {
+      const stream = get.stream.byDigest(CACHE, BIGDIGEST)
+      stream.on('data', () => {})
+      stream.on('error', err => deferred.reject(err))
+      stream.on('end', () => {
+        deferred.resolve()
+      })
+    }
+  })
+}

--- a/test/util/bufferise.js
+++ b/test/util/bufferise.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = bufferise
+function bufferise (string) {
+  return Buffer.from
+  ? Buffer.from(string, 'utf8')
+  : new Buffer(string, 'utf8')
+}


### PR DESCRIPTION
This does something similar to #59 but for `content.read()` and `get()`: There are now bulk operations that read everything into memory in one shot, which can be used for known-small data.

The boost is pretty significant:

### Benchmarks

(NOTE: I don't wanna bother doing cross-version comparisons, but it's probably helpful to point out that `get()` was a tinge slower than `get.stream()` before, and `get.stream()` is unchanged with this PR)

```
================================================
     content.read()
------------------------------------------------
  9660 ops/s @ ~0.104ms/op (±1.23%)
  Sampled 70 in 6.29s.
================================================
     content.read.stream() small data
------------------------------------------------
  3079 ops/s @ ~0.325ms/op (±2.87%)
  Sampled 58 in 6.02s.
================================================
     content.read.stream() big data
------------------------------------------------
  155 ops/s @ ~6.457ms/op (±3.25%)
  Sampled 65 in 5.87s.
================================================
     get.byDigest()
------------------------------------------------
  8278 ops/s @ ~0.121ms/op (±1.98%)
  Sampled 69 in 6.80s.
================================================
     get.byDigest() memoized
------------------------------------------------
  97456 ops/s @ ~0.010ms/op (±1.78%)
  Sampled 79 in 6.03s.
================================================
     get.stream.byDigest() small data
------------------------------------------------
  2898 ops/s @ ~0.345ms/op (±3.06%)
  Sampled 59 in 6.10s.
================================================
     get.stream() big data
------------------------------------------------
  152 ops/s @ ~6.597ms/op (±2.51%)
  Sampled 64 in 5.96s.
================================================
```