### PR TITLE
feat(perf): bulk content write api

### DIFF
--- a/lib/content/write.js
+++ b/lib/content/write.js
@@ -4,10 +4,9 @@ const Promise = require('bluebird')
 
 const checksumStream = require('checksum-stream')
 const contentPath = require('./path')
-const finished = require('mississippi').finished
+const crypto = require('crypto')
 const fixOwner = require('../util/fix-owner')
 const fs = require('graceful-fs')
-const hasContent = require('./read').hasContent
 const moveFile = require('../util/move-file')
 const path = require('path')
 const pipe = require('mississippi').pipe
@@ -16,8 +15,31 @@ const through = require('mississippi').through
 const to = require('mississippi').to
 const uniqueFilename = require('unique-filename')
 
-module.exports = putStream
-function putStream (cache, opts) {
+const writeFileAsync = Promise.promisify(fs.writeFile)
+
+module.exports = write
+function write (cache, data, opts) {
+  opts = opts || {}
+  const digest = crypto.createHash(
+    opts.hashAlgorithm || 'sha512'
+  ).update(data).digest('hex')
+  if (typeof opts.size === 'number' && data.length !== opts.size) {
+    return Promise.reject(sizeError(opts.size, data.length))
+  }
+  if (opts.digest && digest !== opts.digest) {
+    return Promise.reject(checksumError(opts.digest, digest))
+  }
+  return Promise.using(makeTmp(cache, opts), tmp => (
+    writeFileAsync(
+      tmp.target, data, {flag: 'wx'}
+    ).then(() => (
+      moveToDestination(tmp, cache, digest, opts)
+    ))
+  )).then(() => digest)
+}
+
+module.exports.stream = writeStream
+function writeStream (cache, opts) {
   opts = opts || {}
   const inputStream = through()
   let inputErr = false
@@ -53,37 +75,15 @@ function putStream (cache, opts) {
 }
 
 function handleContent (inputStream, cache, opts, errCheck) {
-  const tmpTarget = uniqueFilename(path.join(cache, 'tmp'), opts.tmpPrefix)
-  return (
-    opts.digest
-    ? hasContent(cache, opts.digest)
-    : Promise.resolve(false)
-  ).then(exists => {
+  return Promise.using(makeTmp(cache, opts), tmp => {
     errCheck()
-    // Fast-path-shortcut this if it's already been written.
-    if (exists) {
-      return new Promise((resolve, reject) => {
-        // Slurp it up if they don't close the stream earlier.
-        inputStream.on('data', () => {})
-        finished(inputStream, err => {
-          err ? reject(err) : resolve(opts.digest)
-        })
-      })
-    } else {
-      return fixOwner.mkdirfix(
-        path.dirname(tmpTarget), opts.uid, opts.gid
-      ).then(() => {
-        errCheck()
-        const tmpWritten = pipeToTmp(
-          inputStream, cache, tmpTarget, opts, errCheck)
-        return Promise.using(tmpWritten, digest => {
-          errCheck()
-          return moveToDestination(
-            tmpTarget, cache, digest, opts, errCheck
-          ).then(() => digest)
-        })
-      })
-    }
+    return pipeToTmp(
+      inputStream, cache, tmp.target, opts, errCheck
+    ).then(digest => {
+      return moveToDestination(
+        tmp, cache, digest, opts, errCheck
+      ).then(() => digest)
+    })
   })
 }
 
@@ -102,11 +102,7 @@ function pipeToTmp (inputStream, cache, tmpTarget, opts, errCheck) {
     resolve(fs.createWriteStream(tmpTarget, {
       flags: 'wx'
     }))
-  }).disposer(outStream => new Promise((resolve, reject) => {
-    if (!outStream.fd) { resolve() }
-    outStream.on('error', reject)
-    outStream.on('close', resolve)
-  }))
+  })
   return Promise.using(outStream, outStream => {
     errCheck()
     return new Promise((resolve, reject) => {
@@ -121,23 +117,48 @@ function pipeToTmp (inputStream, cache, tmpTarget, opts, errCheck) {
         }
       })
     })
-  }).disposer(() => {
-    return rimraf(tmpTarget)
   })
 }
 
-function moveToDestination (tmpTarget, cache, digest, opts, errCheck) {
-  errCheck()
+function makeTmp (cache, opts) {
+  const tmpTarget = uniqueFilename(path.join(cache, 'tmp'), opts.tmpPrefix)
+  return fixOwner.mkdirfix(
+    path.dirname(tmpTarget), opts.uid, opts.gid
+  ).then(() => ({
+    target: tmpTarget,
+    moved: false
+  })).disposer(tmp => (!tmp.moved && rimraf(tmp.target)))
+}
+
+function moveToDestination (tmp, cache, digest, opts, errCheck) {
+  errCheck && errCheck()
   const destination = contentPath(cache, digest, opts.hashAlgorithm)
   const destDir = path.dirname(destination)
 
   return fixOwner.mkdirfix(
     destDir, opts.uid, opts.gid
   ).then(() => {
-    errCheck()
-    return moveFile(tmpTarget, destination)
+    errCheck && errCheck()
+    return moveFile(tmp.target, destination)
   }).then(() => {
-    errCheck()
+    errCheck && errCheck()
+    tmp.moved = true
     return fixOwner.chownr(destination, opts.uid, opts.gid)
   })
+}
+
+function sizeError (expected, found) {
+  var err = new Error('stream data size mismatch')
+  err.expected = expected
+  err.found = found
+  err.code = 'EBADSIZE'
+  return err
+}
+
+function checksumError (expected, found) {
+  var err = new Error('checksum failed')
+  err.code = 'EBADCHECKSUM'
+  err.expected = expected
+  err.found = found
+  return err
 }

--- a/test/content.write.chownr.js
+++ b/test/content.write.chownr.js
@@ -20,7 +20,7 @@ test('allows setting a custom uid for cache contents on write', {
   var NEWUID = process.getuid() + 1
   var NEWGID = process.getgid() + 1
   var updatedPaths = []
-  var putStream = requireInject('../lib/content/put-stream', {
+  var write = requireInject('../lib/content/write', {
     chownr: function (p, uid, gid, cb) {
       process.nextTick(function () {
         t.equal(uid, NEWUID, 'new uid set')
@@ -31,7 +31,7 @@ test('allows setting a custom uid for cache contents on write', {
     }
   })
   t.plan(7)
-  pipe(fromString(CONTENT), putStream(CACHE, {
+  pipe(fromString(CONTENT), write.stream(CACHE, {
     uid: NEWUID,
     gid: NEWGID,
     hashAlgorithm: 'sha1'


### PR DESCRIPTION
Fixes: #55

### Benchmarks

```
================================================
     cacache.put()
------------------------------------------------
  1170 ops/s @ ~0.855ms/op (-83.57% ±3.42%)
  Sampled 74 in 6.00s.
================================================
     cacache.put.stream() 2048 bytes
------------------------------------------------
  1001 ops/s @ ~0.999ms/op (-87.58% ±3.46%)
  Sampled 73 in 5.88s.
================================================
     cacache.put.stream() 2048000 bytes
------------------------------------------------
  35.11 ops/s @ ~28.480ms/op (-1.96% ±0.99%)
  Sampled 351 in 34.51s.
================================================
```
