### PR TITLE
transparent cache mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,14 @@ Reading from existing memoized data can be forced by explicitly passing
 `memoize: false` to the reader functions, but their default will be to read from
 memory.
 
+##### `mirror`
+
+Default: null
+
+Can be either a path or array of path. `put` will mirror any writes to a cache
+at this location (or locations, if it's an array). Mirroring will only occur
+after writes to the main cache have been completed, and errors will be ignored.
+
 #### <a name="rm-all"></a> `> cacache.rm.all(cache) -> Promise`
 
 Clears the entire cache. Mainly by blowing away the cache directory itself.

--- a/lib/content/mirror.js
+++ b/lib/content/mirror.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const BB = require('bluebird')
+
+const contentPath = require('./path')
+const copy = require('@npmcorp/copy')
+const fixOwner = require('../util/fix-owner')
+const link = BB.promisify(require('graceful-fs').link)
+const path = require('path')
+
+module.exports = mirror
+function mirror (source, target, digest, opts) {
+  opts = opts || {}
+  const from = contentPath(source, digest, opts.hashAlgorithm)
+  const to = contentPath(target, digest, opts.hashAlgorithm)
+  return fixOwner.mkdirfix(path.dirname(to), opts).then(() => {
+    // prefer hard links, fall back to copy on EXDEV and company
+    return link(from, to).catch(() => copy.file(from, to))
+  })
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   ],
   "license": "CC0-1.0",
   "dependencies": {
+    "@npmcorp/copy": "^1.0.0",
     "@npmcorp/move": "^1.0.0",
     "bluebird": "^3.4.7",
     "checksum-stream": "^1.0.2",


### PR DESCRIPTION
This PR adds mirror read and write support. Mirrors are fast and fairly straightforward: each `content` entry is hard linked when possible (atomically copied otherwise), and index entries are inserted that correspond to these new entries, in each individual mirror.

- [x] mirror writes
- [ ] fallback to mirror on read