### PR TITLE
Segment cache items with another subbucket

### DIFF
--- a/get.js
+++ b/get.js
@@ -35,7 +35,7 @@ function getData (byDigest, cache, key, opts) {
     byDigest ? Promise.resolve(null) : index.find(cache, key, opts)
   ).then(entry => {
     if (!entry && !byDigest) {
-      throw index.notFoundError(cache, key)
+      throw new index.NotFoundError(cache, key)
     }
     return read(cache, byDigest ? key : entry.digest, {
       hashAlgorithm: byDigest ? opts.hashAlgorithm : entry.hashAlgorithm,
@@ -73,7 +73,7 @@ function getStream (cache, key, opts) {
   index.find(cache, key).then(entry => {
     if (!entry) {
       return stream.emit(
-        'error', index.notFoundError(cache, key)
+        'error', new index.NotFoundError(cache, key)
       )
     }
     let memoStream

--- a/lib/content/path.js
+++ b/lib/content/path.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var contentVer = require('../../package.json')['cache-version'].content
+var hashToSegments = require('../util/hash-to-segments')
 var path = require('path')
 
 // Current format of content file path:
@@ -11,11 +12,9 @@ module.exports = contentPath
 function contentPath (cache, address, hashAlgorithm) {
   address = address && address.toLowerCase()
   hashAlgorithm = hashAlgorithm ? hashAlgorithm.toLowerCase() : 'sha512'
-  return path.join(
+  return path.join.apply(path, [
     cache,
     `content-v${contentVer}`,
     hashAlgorithm,
-    address.slice(0, 2),
-    address.slice(2)
-  )
+  ].concat(hashToSegments(address)))
 }

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -1,21 +1,41 @@
 'use strict'
 
-const asyncMap = require('slide/lib/async-map')
+module.exports = {
+  find,
+  insert,
+  ls,
+  lsStream,
+  delete: del,
+  _hashKey: hashKey,
+  _bucketPath: bucketPath
+}
+
 const contentPath = require('./content/path')
 const crypto = require('crypto')
 const fixOwner = require('./util/fix-owner')
 const fs = require('graceful-fs')
 const path = require('path')
 const Promise = require('bluebird')
-const through = require('mississippi').through
-var hashToSegments = require('./util/hash-to-segments')
+const ms = require('mississippi')
+const hashToSegments = require('./util/hash-to-segments')
 
 const indexV = require('../package.json')['cache-version'].index
 
 const appendFileAsync = Promise.promisify(fs.appendFile)
 const readFileAsync = Promise.promisify(fs.readFile)
+const readdirAsync = Promise.promisify(fs.readdir)
+const concat = ms.concat
+const from = ms.from
 
-module.exports.insert = insert
+module.exports.NotFoundError = class NotFoundError extends Error {
+  constructor (cache, key) {
+    super('content not found')
+    this.code = 'ENOENT'
+    this.cache = cache
+    this.key = key
+  }
+}
+
 function insert (cache, key, digest, opts) {
   opts = opts || {}
   const bucket = bucketPath(cache, key)
@@ -47,7 +67,6 @@ function insert (cache, key, digest, opts) {
   ))
 }
 
-module.exports.find = find
 function find (cache, key) {
   const bucket = bucketPath(cache, key)
   return bucketEntries(cache, bucket).then(entries => {
@@ -67,77 +86,56 @@ function find (cache, key) {
   })
 }
 
-module.exports.delete = del
 function del (cache, key) {
   return insert(cache, key, null)
 }
 
-module.exports.lsStream = lsStream
 function lsStream (cache) {
   const indexDir = bucketDir(cache)
-  const stream = through.obj()
-  fs.readdir(indexDir, function (err, buckets) {
-    if (err && err.code === 'ENOENT') {
-      return stream.end()
-    } else if (err) {
-      return stream.emit('error', err)
-    } else {
-      asyncMap(buckets, (bucket, cb) => {
-        fs.readdir(path.join(indexDir, bucket), (err, files) => {
-          if (err && err.code === 'ENOENT') {
-            return cb()
-          } else if (err) {
-            return cb(err)
-          } else {
-            asyncMap(files, function (f, cb) {
-              const bpath = path.join(indexDir, bucket, f)
-              bucketEntries(cache, bpath).then(_entries => {
-                const entries = _entries.reduce((acc, entry) => {
-                  acc[entry.key] = entry
-                  return acc
-                }, {})
-                Object.keys(entries).forEach(function (k) {
-                  stream.write(formatEntry(cache, entries[k]))
-                })
-                cb()
-              }, err => {
-                if (err.code === 'ENOENT') {
-                  cb()
-                } else {
-                  cb(err)
-                }
-              })
-            }, cb)
-          }
-        })
-      }, function (err) {
-        if (err) { stream.emit('error') }
-        stream.end()
-      })
-    }
+  const stream = from.obj()
+
+  // "/cachename/*"
+  readdirAsync(indexDir).map(bucket => {
+    const bucketPath = path.join(indexDir, bucket)
+
+    // "/cachename/<bucket 0xFF>/*"
+    return readdirAsync(bucketPath).map(subbucket => {
+      const subbucketPath = path.join(bucketPath, subbucket)
+
+      // "/cachename/<bucket 0xFF>/<bucket 0xFF>/*"
+      return readdirAsync(subbucketPath).map(entry => {
+        const getKeyToEntry = bucketEntries(
+          cache,
+          path.join(subbucketPath, entry)
+        ).reduce((acc, entry) => {
+          acc.set(entry.key, entry)
+          return acc
+        }, new Map())
+
+        return getKeyToEntry.then(reduced => {
+          return Array.from(reduced.values()).map(
+            entry => stream.push(formatEntry(cache, entry))
+          )
+        }).catch({code: 'ENOENT'}, nop)
+      }).catch({code: 'ENOENT'}, nop)
+    }).catch({code: 'ENOENT'}, nop)
+  }).catch({code: 'ENOENT'}, nop).then(() => {
+    stream.push(null)
+  }, err => {
+    stream.emit('error', err)
   })
   return stream
 }
 
-module.exports.ls = ls
 function ls (cache) {
-  const entries = {}
   return Promise.fromNode(cb => {
-    lsStream(cache).on('finish', function () {
-      cb(null, entries)
-    }).on('data', function (d) {
-      entries[d.key] = d
-    }).on('error', cb)
+    lsStream(cache).on('error', cb).pipe(concat(entries => {
+      cb(null, entries.reduce((acc, xs) => {
+        acc[xs.key] = xs
+        return acc
+      }, {}))
+    }))
   })
-}
-
-module.exports.notFoundError = notFoundError
-function notFoundError (cache, key) {
-  const err = new Error('content not found')
-  err.code = 'ENOENT'
-  err.cache = cache
-  err.key = key
-  return err
 }
 
 function bucketEntries (cache, bucket, filter) {
@@ -170,7 +168,6 @@ function bucketDir (cache) {
   return path.join(cache, `index-v${indexV}`)
 }
 
-module.exports._bucketPath = bucketPath
 function bucketPath (cache, key) {
   const hashed = hashKey(key)
   return path.join.apply(path, [bucketDir(cache)].concat(
@@ -178,7 +175,6 @@ function bucketPath (cache, key) {
   ))
 }
 
-module.exports._hashKey = hashKey
 function hashKey (key) {
   return crypto
   .createHash('sha256')
@@ -195,4 +191,7 @@ function formatEntry (cache, entry) {
     time: entry.time,
     metadata: entry.metadata
   }
+}
+
+function nop () {
 }

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -8,6 +8,7 @@ const fs = require('graceful-fs')
 const path = require('path')
 const Promise = require('bluebird')
 const through = require('mississippi').through
+var hashToSegments = require('./util/hash-to-segments')
 
 const indexV = require('../package.json')['cache-version'].index
 
@@ -172,7 +173,9 @@ function bucketDir (cache) {
 module.exports._bucketPath = bucketPath
 function bucketPath (cache, key) {
   const hashed = hashKey(key)
-  return path.join(bucketDir(cache), hashed.slice(0, 2), hashed.slice(2))
+  return path.join.apply(path, [bucketDir(cache)].concat(
+    hashToSegments(hashed)
+  ))
 }
 
 module.exports._hashKey = hashKey

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -1,15 +1,5 @@
 'use strict'
 
-module.exports = {
-  find,
-  insert,
-  ls,
-  lsStream,
-  delete: del,
-  _hashKey: hashKey,
-  _bucketPath: bucketPath
-}
-
 const contentPath = require('./content/path')
 const crypto = require('crypto')
 const fixOwner = require('./util/fix-owner')
@@ -36,6 +26,7 @@ module.exports.NotFoundError = class NotFoundError extends Error {
   }
 }
 
+module.exports.insert = insert
 function insert (cache, key, digest, opts) {
   opts = opts || {}
   const bucket = bucketPath(cache, key)
@@ -67,6 +58,7 @@ function insert (cache, key, digest, opts) {
   ))
 }
 
+module.exports.find = find
 function find (cache, key) {
   const bucket = bucketPath(cache, key)
   return bucketEntries(cache, bucket).then(entries => {
@@ -86,10 +78,12 @@ function find (cache, key) {
   })
 }
 
+module.exports.delete = del
 function del (cache, key) {
   return insert(cache, key, null)
 }
 
+module.exports.lsStream = lsStream
 function lsStream (cache) {
   const indexDir = bucketDir(cache)
   const stream = from.obj()
@@ -128,6 +122,7 @@ function lsStream (cache) {
   return stream
 }
 
+module.exports.ls = ls
 function ls (cache) {
   return Promise.fromNode(cb => {
     lsStream(cache).on('error', cb).pipe(concat(entries => {
@@ -169,6 +164,7 @@ function bucketDir (cache) {
   return path.join(cache, `index-v${indexV}`)
 }
 
+module.exports._bucketPath = bucketPath
 function bucketPath (cache, key) {
   const hashed = hashKey(key)
   return path.join.apply(path, [bucketDir(cache)].concat(
@@ -176,6 +172,7 @@ function bucketPath (cache, key) {
   ))
 }
 
+module.exports._hashKey = hashKey
 function hashKey (key) {
   return crypto
   .createHash('sha256')

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -95,15 +95,15 @@ function lsStream (cache) {
   const stream = from.obj()
 
   // "/cachename/*"
-  readdirAsync(indexDir).map(bucket => {
+  readdirOrEmpty(indexDir).map(bucket => {
     const bucketPath = path.join(indexDir, bucket)
 
     // "/cachename/<bucket 0xFF>/*"
-    return readdirAsync(bucketPath).map(subbucket => {
+    return readdirOrEmpty(bucketPath).map(subbucket => {
       const subbucketPath = path.join(bucketPath, subbucket)
 
       // "/cachename/<bucket 0xFF>/<bucket 0xFF>/*"
-      return readdirAsync(subbucketPath).map(entry => {
+      return readdirOrEmpty(subbucketPath).map(entry => {
         const getKeyToEntry = bucketEntries(
           cache,
           path.join(subbucketPath, entry)
@@ -117,13 +117,14 @@ function lsStream (cache) {
             entry => stream.push(formatEntry(cache, entry))
           )
         }).catch({code: 'ENOENT'}, nop)
-      }).catch({code: 'ENOENT'}, nop)
-    }).catch({code: 'ENOENT'}, nop)
-  }).catch({code: 'ENOENT'}, nop).then(() => {
+      })
+    })
+  }).then(() => {
     stream.push(null)
   }, err => {
     stream.emit('error', err)
   })
+
   return stream
 }
 
@@ -191,6 +192,10 @@ function formatEntry (cache, entry) {
     time: entry.time,
     metadata: entry.metadata
   }
+}
+
+function readdirOrEmpty (dir) {
+  return readdirAsync(dir).catch({code: 'ENOENT'}, () => [])
 }
 
 function nop () {

--- a/lib/util/hash-to-segments.js
+++ b/lib/util/hash-to-segments.js
@@ -1,0 +1,10 @@
+'use strict'
+
+module.exports = hashToSegments
+
+function hashToSegments (hash) {
+  return [
+    hash.slice(0, 2),
+    hash.slice(2)
+  ]
+}

--- a/lib/util/hash-to-segments.js
+++ b/lib/util/hash-to-segments.js
@@ -5,6 +5,7 @@ module.exports = hashToSegments
 function hashToSegments (hash) {
   return [
     hash.slice(0, 2),
-    hash.slice(2)
+    hash.slice(2, 4),
+    hash.slice(4)
   ]
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "cacache",
   "version": "6.0.1",
   "cache-version": {
-    "content": "1",
-    "index": "1"
+    "content": "2",
+    "index": "2"
   },
   "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "once": "^1.4.0",
     "promise-inflight": "^1.0.1",
     "rimraf": "^2.6.1",
-    "slide": "^1.1.6",
     "unique-filename": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
:ocean: Hi!

This PR adds another sub-bucket to the cache, & centralizes knowledge of how to split a hash into segments into a single util module, `lib/util/hash-to-segments.js`.

This necessitated a change to `lsStream` to take the extra sub-bucket into account. I opted to use bluebird's builtin `.map` and pattern-matched `.catch()` to handle async iteration and ignoring `ENOENT`, respectively. (This eliminated the dependency on `slide`, also.) I switched the stream from `through` to `from`, since it's purely a readable stream, & pulled in `concat` from mississippi to handle `ls`.

As for things that Are Totally Optional And I'm Thinking Maybe I Should Back Them Out (It Is Totally Up To You!), I moved the `module.exports` to the top of the file (using hoisting out of habit to avoid  circular dep issues / get a quick read of what the module exports.) If you'd like I can back out that change!

Thanks, cacache is rad!