### PR TITLE
LRU cache for memoization

### DIFF
--- a/lib/memoization.js
+++ b/lib/memoization.js
@@ -1,11 +1,27 @@
 'use strict'
 
-let MEMOIZED = {}
+const LRU = require('lru-cache')
+
+const MAX_SIZE = 50 * 1024 * 1024 // 50MB
+const MAX_AGE = 3 * 60 * 1000
+
+let MEMOIZED
+clearMemoized()
 
 module.exports.clearMemoized = clearMemoized
 function clearMemoized () {
   var old = MEMOIZED
-  MEMOIZED = {}
+  MEMOIZED = new LRU({
+    max: MAX_SIZE,
+    maxAge: MAX_AGE,
+    length: (entry, key) => {
+      if (key.startsWith('key:')) {
+        return entry.data.length
+      } else if (key.startsWith('digest:')) {
+        return entry.length
+      }
+    }
+  })
   return old
 }
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "chownr": "^1.0.1",
     "glob": "^7.1.1",
     "graceful-fs": "^4.1.10",
+    "lru-cache": "^4.0.2",
     "mississippi": "^1.2.0",
     "mkdirp": "^0.5.1",
     "promise-inflight": "^1.0.1",


### PR DESCRIPTION
Fixes: #74 

This will help make sure that memory use during memoization doesn't grow out of control. It may also allow folks to make more liberal use of `memoize: true` without fretting about blowing stuff up.

This PR is also starting to motivate me to at least add an OO interface to cacache (basically a direct mapping from `cacache.method(cachePath, ...)` to `(new Cacache(path)).method(...)`. Pretty much like JS' API. This would allow users to keep options in the persistent object, and maintain their own tunable in-memory cache, to fit their specific needs. It also makes it really easy to dependency-inject cacache. Pacote could then memoize everything by default and let npm inject its own cache, with its own settings.