### PR TITLE
Subresource Integrity support

### DIFF
--- a/lib/content/path.js
+++ b/lib/content/path.js
@@ -1,21 +1,23 @@
 'use strict'
 
-var contentVer = require('../../package.json')['cache-version'].content
-var hashToSegments = require('../util/hash-to-segments')
-var path = require('path')
+const contentVer = require('../../package.json')['cache-version'].content
+const hashToSegments = require('../util/hash-to-segments')
+const path = require('path')
+const ssri = require('ssri')
 
 // Current format of content file path:
 //
-// ~/.my-cache/content-v1/sha512/ba/bada55deadbeefc0ffee
+// sha512-BaSE64Hex= ->
+// ~/.my-cache/content-v2/sha512/ba/da/55deadbeefc0ffee
 //
 module.exports = contentPath
-function contentPath (cache, address, hashAlgorithm) {
-  address = address && address.toLowerCase()
-  hashAlgorithm = hashAlgorithm ? hashAlgorithm.toLowerCase() : 'sha512'
+function contentPath (cache, integrity) {
+  const sri = ssri.parse(integrity, {single: true})
+  // contentPath is the *strongest* algo given
   return path.join.apply(path, [
     contentDir(cache),
-    hashAlgorithm
-  ].concat(hashToSegments(address)))
+    sri.algorithm
+  ].concat(hashToSegments(sri.hexDigest())))
 }
 
 module.exports._contentDir = contentDir

--- a/lib/content/read.js
+++ b/lib/content/read.js
@@ -2,57 +2,86 @@
 
 const BB = require('bluebird')
 
-const checksumStream = require('checksum-stream')
 const contentPath = require('./path')
-const crypto = require('crypto')
 const fs = require('graceful-fs')
-const pipeline = require('mississippi').pipeline
+const PassThrough = require('stream').PassThrough
+const pipe = BB.promisify(require('mississippi').pipe)
+const ssri = require('ssri')
 
 BB.promisifyAll(fs)
 
 module.exports = read
-function read (cache, address, opts) {
+function read (cache, integrity, opts) {
   opts = opts || {}
-  const algo = opts.hashAlgorithm || 'sha512'
-  const cpath = contentPath(cache, address, algo)
-  return fs.readFileAsync(cpath, null).then(data => {
-    const digest = crypto.createHash(algo).update(data).digest('hex')
-    if (typeof opts.size === 'number' && opts.size !== data.length) {
-      throw sizeError(opts.size, data.length)
-    } else if (digest !== address) {
-      throw checksumError(address, digest)
-    } else {
-      return data
-    }
+  return pickContentSri(cache, integrity).then(sri => {
+    const cpath = contentPath(cache, sri)
+    return fs.readFileAsync(cpath, null).then(data => {
+      if (typeof opts.size === 'number' && opts.size !== data.length) {
+        throw sizeError(opts.size, data.length)
+      } else if (ssri.checkData(data, sri)) {
+        return data
+      } else {
+        throw checksumError(sri, null)
+      }
+    })
   })
 }
 
 module.exports.stream = readStream
 module.exports.readStream = readStream
-function readStream (cache, address, opts) {
+function readStream (cache, integrity, opts) {
   opts = opts || {}
-  const cpath = contentPath(cache, address, opts.hashAlgorithm || 'sha512')
-  return pipeline(
-    fs.createReadStream(cpath), checksumStream({
-      digest: address,
-      algorithm: opts.hashAlgorithm || 'sha512',
-      size: opts.size
-    })
-  )
+  const stream = new PassThrough()
+  pickContentSri(
+    cache, integrity
+  ).then(sri => {
+    return pipe(
+      fs.createReadStream(contentPath(cache, sri)),
+      ssri.integrityStream({
+        integrity: sri,
+        size: opts.size
+      }),
+      stream
+    )
+  }).catch(err => {
+    stream.emit('error', err)
+  })
+  return stream
 }
 
 module.exports.hasContent = hasContent
-function hasContent (cache, address, algorithm) {
-  if (!address) { return BB.resolve(false) }
-  return fs.lstatAsync(
-    contentPath(cache, address, algorithm || 'sha512')
-  ).then(() => true)
+function hasContent (cache, integrity) {
+  if (!integrity) { return BB.resolve(false) }
+  return pickContentSri(cache, integrity, true)
   .catch({code: 'ENOENT'}, () => false)
   .catch({code: 'EPERM'}, err => {
     if (process.platform !== 'win32') {
       throw err
+    } else {
+      return false
     }
-  })
+  }).then(sri => sri || false)
+}
+
+module.exports._pickContentSri = pickContentSri
+function pickContentSri (cache, integrity, checkFs) {
+  const sri = ssri.parse(integrity)
+  // If `integrity` has multiple entries, pick the first digest
+  // with available local data.
+  const algo = sri.pickAlgorithm()
+  const digests = sri[algo]
+  if (digests.length <= 1) {
+    const cpath = contentPath(cache, digests[0])
+    if (checkFs) {
+      return fs.lstatAsync(cpath).then(() => digests[0])
+    } else {
+      return BB.resolve(digests[0])
+    }
+  } else {
+    return BB.any(sri[sri.pickAlgorithm()].map(meta => {
+      return pickContentSri(cache, meta, true)
+    }))
+  }
 }
 
 function sizeError (expected, found) {
@@ -63,10 +92,10 @@ function sizeError (expected, found) {
   return err
 }
 
-function checksumError (expected, found) {
-  var err = new Error('checksum failed')
+function checksumError (sri, path) {
+  var err = new Error(`Checksum failed for ${sri} (${path})`)
   err.code = 'EBADCHECKSUM'
-  err.expected = expected
-  err.found = found
+  err.sri = sri
+  err.path = path
   return err
 }

--- a/lib/content/rm.js
+++ b/lib/content/rm.js
@@ -1,13 +1,16 @@
 'use strict'
 
-var BB = require('bluebird')
+const BB = require('bluebird')
 
-var contentPath = require('./path')
-var rimraf = BB.promisify(require('rimraf'))
+const contentPath = require('./path')
+const hasContent = require('./read').hasContent
+const rimraf = BB.promisify(require('rimraf'))
 
 module.exports = rm
-function rm (cache, address, algorithm) {
-  address = address.toLowerCase()
-  algorithm = algorithm && algorithm.toLowerCase()
-  return rimraf(contentPath(cache, address, algorithm || 'sha512'))
+function rm (cache, integrity) {
+  return hasContent(cache, integrity).then(sri => {
+    if (sri) {
+      return rimraf(contentPath(cache, sri))
+    }
+  })
 }

--- a/lib/content/write.js
+++ b/lib/content/write.js
@@ -2,15 +2,14 @@
 
 const BB = require('bluebird')
 
-const checksumStream = require('checksum-stream')
 const contentPath = require('./path')
-const crypto = require('crypto')
 const fixOwner = require('../util/fix-owner')
 const fs = require('graceful-fs')
 const moveFile = require('../util/move-file')
 const path = require('path')
 const pipe = require('mississippi').pipe
 const rimraf = BB.promisify(require('rimraf'))
+const ssri = require('ssri')
 const through = require('mississippi').through
 const to = require('mississippi').to
 const uniqueFilename = require('unique-filename')
@@ -20,22 +19,25 @@ const writeFileAsync = BB.promisify(fs.writeFile)
 module.exports = write
 function write (cache, data, opts) {
   opts = opts || {}
-  const digest = crypto.createHash(
-    opts.hashAlgorithm || 'sha512'
-  ).update(data).digest('hex')
+  if (opts.algorithms && opts.algorithms.length > 1) {
+    throw new Error(
+      'opts.algorithms only supports a single algorithm for now'
+    )
+  }
   if (typeof opts.size === 'number' && data.length !== opts.size) {
     return BB.reject(sizeError(opts.size, data.length))
   }
-  if (opts.digest && digest !== opts.digest) {
-    return BB.reject(checksumError(opts.digest, digest))
+  const sri = ssri.fromData(data, opts)
+  if (opts.integrity && !ssri.checkData(data, opts.integrity, opts)) {
+    return BB.reject(checksumError(opts.integrity, sri))
   }
   return BB.using(makeTmp(cache, opts), tmp => (
     writeFileAsync(
       tmp.target, data, {flag: 'wx'}
     ).then(() => (
-      moveToDestination(tmp, cache, digest, opts)
+      moveToDestination(tmp, cache, sri, opts)
     ))
-  )).then(() => digest)
+  )).then(() => sri)
 }
 
 module.exports.stream = writeStream
@@ -60,8 +62,8 @@ function writeStream (cache, opts) {
         e.code = 'ENODATA'
         return ret.emit('error', e)
       }
-      allDone.then(digest => {
-        digest && ret.emit('digest', digest)
+      allDone.then(sri => {
+        sri && ret.emit('integrity', sri)
         cb()
       }, e => {
         ret.emit('error', e)
@@ -79,22 +81,22 @@ function handleContent (inputStream, cache, opts, errCheck) {
     errCheck()
     return pipeToTmp(
       inputStream, cache, tmp.target, opts, errCheck
-    ).then(digest => {
+    ).then(sri => {
       return moveToDestination(
-        tmp, cache, digest, opts, errCheck
-      ).then(() => digest)
+        tmp, cache, sri, opts, errCheck
+      ).then(() => sri)
     })
   })
 }
 
 function pipeToTmp (inputStream, cache, tmpTarget, opts, errCheck) {
-  let digest
-  const hashStream = checksumStream({
-    digest: opts.digest,
-    algorithm: opts.hashAlgorithm || 'sha512',
+  let sri
+  const hashStream = ssri.integrityStream({
+    integrity: opts.integrity,
+    algorithms: opts.algorithms,
     size: opts.size
-  }).on('digest', d => {
-    digest = d
+  }).on('integrity', s => {
+    sri = s
   })
 
   let outStream = new BB((resolve, reject) => {
@@ -113,7 +115,7 @@ function pipeToTmp (inputStream, cache, tmpTarget, opts, errCheck) {
         if (err) {
           rimraf(tmpTarget).then(() => reject(err), reject)
         } else {
-          resolve(digest)
+          resolve(sri)
         }
       })
     })
@@ -130,9 +132,9 @@ function makeTmp (cache, opts) {
   })).disposer(tmp => (!tmp.moved && rimraf(tmp.target)))
 }
 
-function moveToDestination (tmp, cache, digest, opts, errCheck) {
+function moveToDestination (tmp, cache, sri, opts, errCheck) {
   errCheck && errCheck()
-  const destination = contentPath(cache, digest, opts.hashAlgorithm)
+  const destination = contentPath(cache, sri)
   const destDir = path.dirname(destination)
 
   return fixOwner.mkdirfix(

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -1,13 +1,15 @@
 'use strict'
 
+const BB = require('bluebird')
+
 const contentPath = require('./content/path')
 const crypto = require('crypto')
 const fixOwner = require('./util/fix-owner')
 const fs = require('graceful-fs')
-const path = require('path')
-const BB = require('bluebird')
-const ms = require('mississippi')
 const hashToSegments = require('./util/hash-to-segments')
+const ms = require('mississippi')
+const path = require('path')
+const ssri = require('ssri')
 
 const indexV = require('../package.json')['cache-version'].index
 
@@ -27,14 +29,13 @@ module.exports.NotFoundError = class NotFoundError extends Error {
 }
 
 module.exports.insert = insert
-function insert (cache, key, digest, opts) {
+function insert (cache, key, integrity, opts) {
   opts = opts || {}
   const bucket = bucketPath(cache, key)
   const entry = {
-    key: key,
-    digest: digest,
-    hashAlgorithm: opts.hashAlgorithm || 'sha512',
-    time: +(new Date()),
+    key,
+    integrity: integrity && ssri.stringify(integrity),
+    time: Date.now(),
     metadata: opts.metadata
   }
   return fixOwner.mkdirfix(
@@ -85,8 +86,8 @@ function find (cache, key) {
 }
 
 module.exports.delete = del
-function del (cache, key) {
-  return insert(cache, key, null)
+function del (cache, key, opts) {
+  return insert(cache, key, null, opts)
 }
 
 module.exports.lsStream = lsStream
@@ -200,12 +201,11 @@ function hash (str, digest) {
 
 function formatEntry (cache, entry) {
   // Treat null digests as deletions. They'll shadow any previous entries.
-  if (!entry.digest) { return null }
+  if (!entry.integrity) { return null }
   return {
     key: entry.key,
-    digest: entry.digest,
-    hashAlgorithm: entry.hashAlgorithm,
-    path: contentPath(cache, entry.digest, entry.hashAlgorithm),
+    integrity: entry.integrity,
+    path: contentPath(cache, entry.integrity),
     time: entry.time,
     metadata: entry.metadata
   }

--- a/lib/memoization.js
+++ b/lib/memoization.js
@@ -28,12 +28,12 @@ function clearMemoized () {
 module.exports.put = put
 function put (cache, entry, data) {
   MEMOIZED[`key:${cache}:${entry.key}`] = { entry, data }
-  putDigest(cache, entry.digest, entry.hashAlgorithm, data)
+  putDigest(cache, entry.integrity, data)
 }
 
 module.exports.put.byDigest = putDigest
-function putDigest (cache, digest, algo, data) {
-  MEMOIZED[`digest:${cache}:${algo}:${digest}`] = data
+function putDigest (cache, integrity, data) {
+  MEMOIZED[`digest:${cache}:${integrity}`] = data
 }
 
 module.exports.get = get
@@ -42,6 +42,6 @@ function get (cache, key) {
 }
 
 module.exports.get.byDigest = getDigest
-function getDigest (cache, digest, algo) {
-  return MEMOIZED[`digest:${cache}:${algo}:${digest}`]
+function getDigest (cache, integrity) {
+  return MEMOIZED[`digest:${cache}:${integrity}`]
 }

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -2,7 +2,6 @@
 
 const BB = require('bluebird')
 
-const checksumStream = require('checksum-stream')
 const contentPath = require('./content/path')
 const finished = BB.promisify(require('mississippi').finished)
 const fixOwner = require('./util/fix-owner')
@@ -12,6 +11,7 @@ const index = require('./entry-index')
 const path = require('path')
 const pipe = BB.promisify(require('mississippi').pipe)
 const rimraf = BB.promisify(require('rimraf'))
+const ssri = require('ssri')
 
 BB.promisifyAll(fs)
 
@@ -65,7 +65,7 @@ function fixPerms (cache, opts) {
 //
 // The algorithm is basically as follows:
 // 1. Read (and filter) all index entries ("pointers")
-// 2. Mark each algo/digest combo as "live"
+// 2. Mark each integrity value as "live"
 // 3. Read entire filesystem tree in `content-vX/` dir
 // 4. If content is live, verify its checksum and delete it if it fails
 // 5. If content is not marked as live, rimraf it.
@@ -76,7 +76,7 @@ function garbageCollect (cache, opts) {
   const liveContent = new Set()
   indexStream.on('data', entry => {
     if (opts && opts.filter && !opts.filter(entry)) { return }
-    liveContent.add(`${entry.hashAlgorithm}-${entry.digest}`)
+    liveContent.add(entry.integrity.toString())
   })
   return finished(indexStream).then(() => {
     const contentDir = contentPath._contentDir(cache)
@@ -95,8 +95,9 @@ function garbageCollect (cache, opts) {
         const split = f.split(/[/\\]/)
         const digest = split.slice(split.length - 3).join('')
         const algo = split[split.length - 4]
-        if (liveContent.has(`${algo}-${digest}`)) {
-          return verifyContent(f, digest, algo).then(info => {
+        const integrity = ssri.fromHex(digest, algo)
+        if (liveContent.has(integrity.toString())) {
+          return verifyContent(f, integrity).then(info => {
             if (!info.valid) {
               stats.reclaimedCount++
               stats.badContentCount++
@@ -122,16 +123,17 @@ function garbageCollect (cache, opts) {
   })
 }
 
-function verifyContent (filepath, digest, algorithm) {
+function verifyContent (filepath, sri) {
   return fs.statAsync(filepath).then(stat => {
-    const reader = fs.createReadStream(filepath)
-    const checksummer = checksumStream({digest, algorithm})
     const contentInfo = {
       size: stat.size,
       valid: true
     }
-    checksummer.on('data', () => {})
-    return pipe(reader, checksummer).catch({code: 'EBADCHECKSUM'}, () => {
+    return ssri.checkStream(
+      fs.createReadStream(filepath),
+      sri
+    ).catch(err => {
+      if (err.code !== 'EBADCHECKSUM') { throw err }
       return rimraf(filepath).then(() => {
         contentInfo.valid = false
       })
@@ -178,12 +180,11 @@ function rebuildBucket (cache, bucket, stats, opts) {
     // This needs to be serialized because cacache explicitly
     // lets very racy bucket conflicts clobber each other.
     return BB.mapSeries(bucket, entry => {
-      const content = contentPath(cache, entry.digest, entry.hashAlgorithm)
+      const content = contentPath(cache, entry.integrity)
       return fs.statAsync(content).then(() => {
-        return index.insert(cache, entry.key, entry.digest, {
+        return index.insert(cache, entry.key, entry.integrity, {
           uid: opts.uid,
           gid: opts.gid,
-          hashAlgorithm: entry.hashAlgorithm,
           metadata: entry.metadata
         }).then(() => { stats.totalEntries++ })
       }).catch({code: 'ENOENT'}, () => {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.3.0",
   "cache-version": {
     "content": "2",
-    "index": "3"
+    "index": "4"
   },
   "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
   "main": "index.js",
@@ -46,7 +46,6 @@
   ],
   "license": "CC0-1.0",
   "dependencies": {
-    "move-concurrently": "^1.0.0",
     "bluebird": "^3.4.7",
     "checksum-stream": "^1.0.2",
     "chownr": "^1.0.1",
@@ -55,8 +54,10 @@
     "lru-cache": "^4.0.2",
     "mississippi": "^1.2.0",
     "mkdirp": "^0.5.1",
+    "move-concurrently": "^1.0.0",
     "promise-inflight": "^1.0.1",
     "rimraf": "^2.6.1",
+    "ssri": "^3.0.0",
     "unique-filename": "^1.1.0"
   },
   "devDependencies": {

--- a/put.js
+++ b/put.js
@@ -8,12 +8,12 @@ const to = require('mississippi').to
 module.exports = putData
 function putData (cache, key, data, opts) {
   opts = opts || {}
-  return write(cache, data, opts).then(digest => {
-    return index.insert(cache, key, digest, opts).then(entry => {
+  return write(cache, data, opts).then(integrity => {
+    return index.insert(cache, key, integrity, opts).then(entry => {
       if (opts.memoize) {
         memo.put(cache, entry, data)
       }
-      return digest
+      return integrity
     })
   })
 }
@@ -21,9 +21,9 @@ function putData (cache, key, data, opts) {
 module.exports.stream = putStream
 function putStream (cache, key, opts) {
   opts = opts || {}
-  let digest
-  const contentStream = write.stream(cache, opts).on('digest', d => {
-    digest = d
+  let integrity
+  const contentStream = write.stream(cache, opts).on('integrity', int => {
+    integrity = int
   })
   let memoData
   let memoTotal = 0
@@ -38,11 +38,11 @@ function putStream (cache, key, opts) {
     })
   }, cb => {
     contentStream.end(() => {
-      index.insert(cache, key, digest, opts).then(entry => {
+      index.insert(cache, key, integrity, opts).then(entry => {
         if (opts.memoize) {
           memo.put(cache, entry, Buffer.concat(memoData, memoTotal))
         }
-        stream.emit('digest', digest)
+        stream.emit('integrity', integrity)
         cb()
       })
     })

--- a/rm.js
+++ b/rm.js
@@ -16,9 +16,9 @@ function entry (cache, key) {
 }
 
 module.exports.content = content
-function content (cache, address) {
+function content (cache, integrity) {
   memo.clearMemoized()
-  return rmContent(cache, address)
+  return rmContent(cache, integrity)
 }
 
 module.exports.all = all

--- a/test/benchmarks/content.read.js
+++ b/test/benchmarks/content.read.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const CacheContent = require('../util/cache-content')
-const crypto = require('crypto')
 const Tacks = require('tacks')
+const ssri = require('ssri')
 
 const read = require('../../lib/content/read')
 
@@ -12,27 +12,27 @@ for (let i = 0; i < Math.pow(2, 8); i++) {
 }
 
 const CONTENT = Buffer.concat(buf, buf.length * 8)
-const DIGEST = crypto.createHash('sha512').update(CONTENT).digest('hex')
+const INTEGRITY = ssri.fromData(CONTENT)
 
 const arr = []
 for (let i = 0; i < 100; i++) {
   arr.push(CONTENT)
 }
 const BIGCONTENT = Buffer.concat(arr, CONTENT.length * 1000)
-const BIGDIGEST = crypto.createHash('sha512').update(BIGCONTENT).digest('hex')
+const BIGINTEGRITY = ssri.fromData(BIGCONTENT)
 
 module.exports = (suite, CACHE) => {
   suite.add('content.read()', {
     defer: true,
     setup () {
       const fixture = new Tacks(CacheContent({
-        [DIGEST]: CONTENT
+        [INTEGRITY]: CONTENT
       }))
       fixture.create(CACHE)
     },
     fn (deferred) {
       read(
-        CACHE, DIGEST
+        CACHE, INTEGRITY
       ).then(
         () => deferred.resolve(),
         err => deferred.reject(err)
@@ -44,13 +44,13 @@ module.exports = (suite, CACHE) => {
     defer: true,
     setup () {
       const fixture = new Tacks(CacheContent({
-        [BIGDIGEST]: BIGCONTENT
+        [BIGINTEGRITY]: BIGCONTENT
       }))
       fixture.create(CACHE)
     },
     fn (deferred) {
       read(
-        CACHE, BIGDIGEST
+        CACHE, BIGINTEGRITY
       ).then(
         () => deferred.resolve(),
         err => deferred.reject(err)
@@ -62,12 +62,12 @@ module.exports = (suite, CACHE) => {
     defer: true,
     setup () {
       const fixture = new Tacks(CacheContent({
-        [DIGEST]: CONTENT
+        [INTEGRITY]: CONTENT
       }))
       fixture.create(CACHE)
     },
     fn (deferred) {
-      const stream = read.stream(CACHE, DIGEST)
+      const stream = read.stream(CACHE, INTEGRITY)
       stream.on('data', () => {})
       stream.on('error', err => deferred.reject(err))
       stream.on('end', () => {
@@ -80,12 +80,12 @@ module.exports = (suite, CACHE) => {
     defer: true,
     setup () {
       const fixture = new Tacks(CacheContent({
-        [BIGDIGEST]: BIGCONTENT
+        [BIGINTEGRITY]: BIGCONTENT
       }))
       fixture.create(CACHE)
     },
     fn (deferred) {
-      const stream = read.stream(CACHE, BIGDIGEST)
+      const stream = read.stream(CACHE, BIGINTEGRITY)
       stream.on('data', () => {})
       stream.on('error', err => deferred.reject(err))
       stream.on('end', () => {

--- a/test/benchmarks/index.find.js
+++ b/test/benchmarks/index.find.js
@@ -19,8 +19,7 @@ module.exports = (suite, CACHE) => {
     onStart () {
       const entry = {
         key: 'whatever',
-        digest: 'deadbeef',
-        hashAlgorithm: 'whatnot',
+        integrity: 'sha512-deadbeef',
         time: 12345,
         metadata: 'omgsometa'
       }

--- a/test/benchmarks/index.insert.js
+++ b/test/benchmarks/index.insert.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const KEY = 'foo'
-const DIGEST = 'deadbeef'
+const INTEGRITY = 'sha512-deadbeef'
 const ALGO = 'whatnot'
 
 const index = require('../../lib/entry-index')
@@ -10,9 +10,8 @@ module.exports = (suite, CACHE) => {
   suite.add('index.insert() different files', {
     defer: true,
     fn (deferred) {
-      index.insert(CACHE, KEY + this.count, DIGEST, {
-        metadata: 'foo',
-        hashAlgorithm: ALGO
+      index.insert(CACHE, KEY + this.count, INTEGRITY, {
+        metadata: 'foo'
       }).then(
         () => deferred.resolve(),
         err => deferred.reject(err)
@@ -22,7 +21,7 @@ module.exports = (suite, CACHE) => {
   suite.add('index.insert() same file', {
     defer: true,
     fn (deferred) {
-      index.insert(CACHE, KEY, DIGEST, {
+      index.insert(CACHE, KEY, INTEGRITY, {
         metadata: 'foo',
         hashAlgorithm: ALGO
       }).then(

--- a/test/content.rm.js
+++ b/test/content.rm.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const contentPath = require('../lib/content/path')
 const fs = require('graceful-fs')
 const path = require('path')
 const BB = require('bluebird')
@@ -10,21 +11,16 @@ const testDir = require('./util/test-dir')(__filename)
 BB.promisifyAll(fs)
 
 const CACHE = path.join(testDir, 'cache')
-const Dir = Tacks.Dir
-const File = Tacks.File
+const CacheContent = require('./util/cache-content')
 const rm = require('../lib/content/rm')
 
 test('removes a content entry', function (t) {
-  const fixture = new Tacks(Dir({
-    'content': Dir({
-      'de': Dir({
-        'deadbeef': File('')
-      })
-    })
+  const fixture = new Tacks(CacheContent({
+    'sha1-deadbeef': ''
   }))
   fixture.create(CACHE)
-  return rm(CACHE, 'deadbeef').then(() => (
-    fs.statAsync(path.join(CACHE, 'content', 'deadbeef'))
+  return rm(CACHE, 'sha1-deadbeef').then(() => (
+    fs.statAsync(contentPath(CACHE, 'sha1-deadbeef'))
   )).then(() => {
     throw new Error('expected an error')
   }).catch(err => {
@@ -34,10 +30,10 @@ test('removes a content entry', function (t) {
 })
 
 test('works fine if entry missing', function (t) {
-  const fixture = new Tacks(Dir({}))
+  const fixture = new Tacks(CacheContent({}))
   fixture.create(CACHE)
-  return rm(CACHE, 'deadbeef').then(() => (
-    fs.statAsync(path.join(CACHE, 'content', 'deadbeef'))
+  return rm(CACHE, 'sha1-deadbeef').then(() => (
+    fs.statAsync(contentPath(CACHE, 'sha1-deadbeef'))
   )).then(() => {
     throw new Error('expected an error')
   }).catch(err => {

--- a/test/content.write.js
+++ b/test/content.write.js
@@ -6,154 +6,152 @@ const fs = require('fs')
 const path = require('path')
 const pipe = require('mississippi').pipe
 const rimraf = require('rimraf')
+const ssri = require('ssri')
 const Tacks = require('tacks')
 const test = require('tap').test
 const testDir = require('./util/test-dir')(__filename)
 
 const CACHE = path.join(testDir, 'cache')
+const CacheContent = require('./util/cache-content')
 const contentPath = require('../lib/content/path')
-const Dir = Tacks.Dir
-const File = Tacks.File
 
 const write = require('../lib/content/write')
 
-test('basic put', function (t) {
+test('basic put', t => {
   const CONTENT = 'foobarbaz'
   // Default is sha512
-  const DIGEST = crypto.createHash('sha512').update(CONTENT).digest('hex')
-  let foundDigest
+  const INTEGRITY = ssri.fromData(CONTENT)
+  let integrity
   const src = fromString(CONTENT)
-  const stream = write.stream(CACHE).on('digest', function (d) {
-    foundDigest = d
+  const stream = write.stream(CACHE).on('integrity', i => {
+    integrity = i
   })
-  pipe(src, stream, function (err) {
+  pipe(src, stream, err => {
     if (err) { throw err }
-    const cpath = contentPath(CACHE, foundDigest)
+    const cpath = contentPath(CACHE, integrity)
     t.plan(3)
-    t.equal(foundDigest, DIGEST, 'returned digest matches expected')
-    fs.lstat(cpath, function (err, stat) {
+    t.deepEqual(integrity, INTEGRITY, 'calculated integrity value matches')
+    fs.lstat(cpath, (err, stat) => {
       if (err) { throw err }
       t.ok(stat.isFile(), 'content inserted as a single file')
     })
-    fs.readFile(cpath, 'utf8', function (err, data) {
+    fs.readFile(cpath, 'utf8', (err, data) => {
       if (err) { throw err }
       t.equal(data, CONTENT, 'contents are identical to inserted content')
     })
   })
 })
 
-test('checks input digest doesn\'t match data', function (t) {
+test('checks input digest doesn\'t match data', t => {
   const CONTENT = 'foobarbaz'
-  const DIGEST = crypto.createHash('sha512').update(CONTENT).digest('hex')
+  const INTEGRITY = ssri.fromData(CONTENT)
   t.plan(5)
-  let foundDigest1
-  let foundDigest2
+  let int1
+  let int2
   pipe(fromString('bazbarfoo'), write.stream(CACHE, {
-    digest: DIGEST
-  }).on('digest', function (d) {
-    foundDigest1 = d
-  }), function (err) {
-    t.ok(!foundDigest1, 'no digest emitted')
+    integrity: INTEGRITY
+  }).on('integrity', int => {
+    int1 = int
+  }), err => {
+    t.ok(!int1, 'no digest emitted')
     t.ok(!!err, 'got an error')
     t.equal(err.code, 'EBADCHECKSUM', 'returns a useful error code')
   })
   pipe(fromString(CONTENT), write.stream(CACHE, {
-    digest: DIGEST
-  }).on('digest', function (d) {
-    foundDigest2 = d
-  }), function (err) {
+    integrity: INTEGRITY
+  }).on('integrity', int => {
+    int2 = int
+  }), err => {
     t.ok(!err, 'completed without error')
-    t.equal(foundDigest2, DIGEST, 'returns a matching digest')
+    t.deepEqual(int2, INTEGRITY, 'returns a matching digest')
   })
 })
 
-test('errors if stream ends with no data', function (t) {
-  let foundDigest = null
-  pipe(fromString(''), write.stream(CACHE).on('digest', function (d) {
-    foundDigest = d
-  }), function (err) {
+test('errors if stream ends with no data', t => {
+  let integrity = null
+  pipe(fromString(''), write.stream(CACHE).on('integrity', int => {
+    integrity = int
+  }), err => {
     t.ok(err, 'got an error')
-    t.equal(foundDigest, null, 'no digest returned')
+    t.equal(integrity, null, 'no digest returned')
     t.equal(err.code, 'ENODATA', 'returns useful error code')
     t.end()
   })
 })
 
-test('errors if input size does not match expected', function (t) {
+test('errors if input size does not match expected', t => {
   t.plan(10)
-  let dig1 = null
+  let int1 = null
   pipe(fromString('abc'), write.stream(CACHE, {
     size: 5
-  }).on('digest', function (d) {
-    dig1 = d
-  }), function (err) {
+  }).on('integrity', int => {
+    int1 = int
+  }), err => {
     t.ok(err, 'got an error when data smaller than expected')
-    t.equal(dig1, null, 'no digest returned')
+    t.equal(int1, null, 'no digest returned')
     t.equal(err.code, 'EBADSIZE', 'returns useful error code')
     t.equal(err.expected, 5, 'error includes expected size')
     t.equal(err.found, 3, 'error includes found size')
   })
-  let dig2 = null
+  let int2 = null
   pipe(fromString('abcdefghi'), write.stream(CACHE, {
     size: 5
-  }).on('digest', function (d) {
-    dig2 = d
-  }), function (err) {
+  }).on('integrity', int => {
+    int2 = int
+  }), err => {
     t.ok(err, 'got an error when data bigger than expected')
-    t.equal(dig2, null, 'no digest returned')
+    t.equal(int2, null, 'no digest returned')
     t.equal(err.code, 'EBADSIZE', 'returns useful error code')
     t.equal(err.expected, 5, 'error includes expected size')
     t.equal(err.found, 9, 'error includes found size')
   })
 })
 
-test('does not overwrite content if already on disk', function (t) {
+test('does not overwrite content if already on disk', t => {
   const CONTENT = 'foobarbaz'
-  const DIGEST = crypto.createHash('sha512').update(CONTENT).digest('hex')
-  const contentDir = {}
-  contentDir[DIGEST] = File('nope')
-  const fixture = new Tacks(Dir({
-    'content': Dir(contentDir)
+  const INTEGRITY = ssri.fromData(CONTENT)
+  const fixture = new Tacks(CacheContent({
+    [INTEGRITY]: 'nope'
   }))
   fixture.create(CACHE)
   t.plan(4)
-  let dig1
-  let dig2
+  let int1
+  let int2
   // With a digest -- early short-circuiting
   pipe(fromString(CONTENT), write.stream(CACHE, {
-    digest: DIGEST
-  }).on('digest', function (d) {
-    dig1 = d
-  }), function (err) {
+    integrity: INTEGRITY
+  }).on('integrity', int => {
+    int1 = int
+  }), err => {
     if (err) { throw err }
-    t.equal(dig1, DIGEST, 'short-circuit returns a matching digest')
-    fs.readFile(path.join(CACHE, 'content', DIGEST), 'utf8', function (e, d) {
+    t.deepEqual(int1, INTEGRITY, 'short-circuit returns a matching digest')
+    fs.readFile(contentPath(CACHE, INTEGRITY), 'utf8', (e, d) => {
       if (e) { throw e }
       t.equal(d, 'nope', 'process short-circuited. Data not written.')
     })
   })
-  pipe(fromString(CONTENT), write.stream(CACHE).on('digest', function (d) {
-    dig2 = d
-  }), function (err) {
+  pipe(fromString(CONTENT), write.stream(CACHE).on('integrity', int => {
+    int2 = int
+  }), err => {
     if (err) { throw err }
-    t.equal(dig2, DIGEST, 'full write returns a matching digest')
-    fs.readFile(path.join(CACHE, 'content', DIGEST), 'utf8', function (e, d) {
+    t.deepEqual(int2, INTEGRITY, 'full write returns a matching digest')
+    fs.readFile(contentPath(CACHE, INTEGRITY), 'utf8', function (e, d) {
       if (e) { throw e }
       t.equal(d, 'nope', 'previously-written data intact - no dupe write')
     })
   })
 })
 
-test('errors if input stream errors', function (t) {
+test('errors if input stream errors', t => {
   const stream = fromString('foobarbaz')
   .on('end', () => stream.emit('error', new Error('bleh')))
-  let foundDigest
-  const putter = write.stream(CACHE).on('digest', function (d) {
-    foundDigest = d
+  let integrity
+  const putter = write.stream(CACHE).on('integrity', int => {
+    integrity = int
   })
-  pipe(stream, putter, function (err) {
+  pipe(stream, putter, err => {
     t.ok(err, 'got an error')
-    t.ok(!foundDigest, 'no digest returned')
+    t.ok(!integrity, 'no digest returned')
     t.match(err && err.message, 'bleh', 'returns the error from input stream')
     fs.readdir(testDir, (err, files) => {
       if (err) { throw err }
@@ -163,29 +161,26 @@ test('errors if input stream errors', function (t) {
   })
 })
 
-test('exits normally if file already open', function (t) {
+test('exits normally if file already open', t => {
   const CONTENT = 'foobarbaz'
-  const DIGEST = crypto.createHash('sha512').update(CONTENT).digest('hex')
-  const PATH = path.join(CACHE, 'content', DIGEST)
-  const contentDir = {}
-  contentDir[DIGEST] = File(CONTENT)
-  const fixture = new Tacks(Dir({
-    'content': Dir(contentDir)
+  const INTEGRITY = ssri.fromData(CONTENT)
+  const fixture = new Tacks(CacheContent({
+    [INTEGRITY]: CONTENT
   }))
-  let foundDigest
+  let integrity
   fixture.create(CACHE)
   // This case would only fail on Windows, when an entry is being read.
   // Generally, you'd get an EBUSY back.
-  fs.open(PATH, 'r+', function (err, fd) {
+  fs.open(contentPath(CACHE, INTEGRITY), 'r+', function (err, fd) {
     if (err) { throw err }
-    pipe(fromString(CONTENT), write.stream(CACHE).on('digest', function (d) {
-      foundDigest = d
-    }), function (err) {
+    pipe(fromString(CONTENT), write.stream(CACHE).on('integrity', int => {
+      integrity = int
+    }), err => {
       if (err) { throw err }
-      t.equal(foundDigest, DIGEST, 'returns a matching digest')
-      fs.close(fd, function (err) {
+      t.deepEqual(integrity, INTEGRITY, 'returns a matching digest')
+      fs.close(fd, err => {
         if (err) { throw err }
-        rimraf(PATH, function (err) {
+        rimraf(contentPath(CACHE, INTEGRITY), err => {
           if (err) { throw err }
           t.end()
         })
@@ -194,9 +189,9 @@ test('exits normally if file already open', function (t) {
   })
 })
 
-test('cleans up tmp on successful completion', function (t) {
+test('cleans up tmp on successful completion', t => {
   const CONTENT = 'foobarbaz'
-  pipe(fromString(CONTENT), write.stream(CACHE), function (err) {
+  pipe(fromString(CONTENT), write.stream(CACHE), err => {
     if (err) { throw err }
     const tmp = path.join(CACHE, 'tmp')
     fs.readdir(tmp, function (err, files) {
@@ -211,9 +206,9 @@ test('cleans up tmp on successful completion', function (t) {
   })
 })
 
-test('cleans up tmp on error', function (t) {
+test('cleans up tmp on error', t => {
   const CONTENT = 'foobarbaz'
-  pipe(fromString(CONTENT), write.stream(CACHE, { size: 1 }), function (err) {
+  pipe(fromString(CONTENT), write.stream(CACHE, { size: 1 }), err => {
     t.ok(err, 'got an error')
     t.equal(err.code, 'EBADSIZE', 'got expected code')
     const tmp = path.join(CACHE, 'tmp')
@@ -229,18 +224,18 @@ test('cleans up tmp on error', function (t) {
   })
 })
 
-test('checks the size of stream data if opts.size provided', function (t) {
+test('checks the size of stream data if opts.size provided', t => {
   const CONTENT = 'foobarbaz'
-  let dig1, dig2, dig3
+  let int1, int2, int3
   t.plan(8)
   pipe(
     fromString(CONTENT.slice(3)),
     write.stream(CACHE, {
       size: CONTENT.length
-    }).on('digest', function (d) { dig1 = d }),
-    function (err) {
+    }).on('integrity', int => { int1 = int }),
+    err => {
       t.ok(!!err, 'got an error')
-      t.ok(!dig1, 'no digest returned')
+      t.ok(!int1, 'no digest returned')
       t.equal(err.code, 'EBADSIZE', 'returns a useful error code')
     }
   )
@@ -248,10 +243,10 @@ test('checks the size of stream data if opts.size provided', function (t) {
     fromString(CONTENT + 'quux'),
     write.stream(CACHE, {
       size: CONTENT.length
-    }).on('digest', function (d) { dig2 = d }),
-    function (err) {
+    }).on('integrity', int => { int2 = int }),
+    err => {
       t.ok(!!err, 'got an error')
-      t.ok(!dig2, 'no digest returned')
+      t.ok(!int2, 'no digest returned')
       t.equal(err.code, 'EBADSIZE', 'returns a useful error code')
     }
   )
@@ -259,10 +254,10 @@ test('checks the size of stream data if opts.size provided', function (t) {
     fromString(CONTENT),
     write.stream(CACHE, {
       size: CONTENT.length
-    }).on('digest', function (d) { dig3 = d }),
-    function (err) {
+    }).on('integrity', int => { int3 = int }),
+    err => {
       t.ifError(err, 'completed without error')
-      t.ok(dig3, 'got a digest')
+      t.ok(int3, 'got a digest')
     }
   )
 })

--- a/test/index.find.js
+++ b/test/index.find.js
@@ -17,8 +17,7 @@ const index = require('../lib/entry-index')
 test('index.find cache hit', function (t) {
   const entry = {
     key: 'whatever',
-    digest: 'deadbeef',
-    hashAlgorithm: 'whatnot',
+    integrity: 'whatnot-deadbeef',
     time: 12345,
     metadata: 'omgsometa'
   }
@@ -32,7 +31,7 @@ test('index.find cache hit', function (t) {
     t.ok(info, 'cache hit')
     t.equal(
       info.path,
-      contentPath(CACHE, entry.digest, entry.hashAlgorithm),
+      contentPath(CACHE, entry.integrity),
       'path added to info'
     )
     delete info.path
@@ -68,12 +67,12 @@ test('index.find key case-sensitivity', function (t) {
   const fixture = new Tacks(CacheIndex({
     'jsonstream': {
       key: 'jsonstream',
-      digest: 'lowercase',
+      integrity: 'sha1-lowercase',
       time: 54321
     },
     'JSONStream': {
       key: 'JSONStream',
-      digest: 'capitalised',
+      integrity: 'sha1-capitalised',
       time: 12345
     }
   }))
@@ -96,9 +95,8 @@ test('index.find key case-sensitivity', function (t) {
 test('index.find path-breaking characters', function (t) {
   const entry = {
     key: ';;!registry\nhttps://registry.npmjs.org/back \\ slash@Cool™?',
-    digest: 'deadbeef',
+    integrity: 'sha1-deadbeef',
     time: 12345,
-    hashAlgorithm: 'whatnot',
     metadata: 'omgsometa'
   }
   const fixture = new Tacks(CacheIndex({
@@ -123,9 +121,8 @@ test('index.find extremely long keys', function (t) {
   }
   const entry = {
     key: key,
-    digest: 'deadbeef',
+    integrity: 'sha1-deadbeef',
     time: 12345,
-    hashAlgorithm: 'whatnot',
     metadata: 'woo'
   }
   const fixture = new Tacks(CacheIndex({
@@ -147,14 +144,14 @@ test('index.find multiple index entries for key', function (t) {
   const key = 'whatever'
   const fixture = new Tacks(CacheIndex({
     'whatever': [
-      { key: key, digest: 'deadbeef', time: 54321 },
-      { key: key, digest: 'bada55', time: 12345 }
+      { key: key, integrity: 'sha1-deadbeef', time: 54321 },
+      { key: key, integrity: 'sha1-bada55', time: 12345 }
     ]
   }))
   fixture.create(CACHE)
   return index.find(CACHE, key).then(info => {
     t.ok(info, 'cache hit')
-    t.equal(info.digest, 'bada55', 'most recent entry wins')
+    t.equal(info.integrity, 'sha1-bada55', 'most recent entry wins')
   })
 })
 
@@ -172,7 +169,7 @@ test('index.find garbled data in index file', function (t) {
   const key = 'whatever'
   const stringified = JSON.stringify({
     key: key,
-    digest: 'deadbeef',
+    integrity: 'sha1-deadbeef',
     time: 54321
   })
   const fixture = new Tacks(CacheIndex({
@@ -183,7 +180,7 @@ test('index.find garbled data in index file', function (t) {
   fixture.create(CACHE)
   return index.find(CACHE, key).then(info => {
     t.ok(info, 'cache hit in spite of crash-induced fail')
-    t.equal(info.digest, 'deadbeef', ' recent entry wins')
+    t.equal(info.integrity, 'sha1-deadbeef', ' recent entry wins')
   })
 })
 
@@ -191,16 +188,15 @@ test('index.find hash conflict in same bucket', function (t) {
   // This... is very unlikely to happen. But hey.
   const entry = {
     key: 'whatever',
-    digest: 'deadbeef',
-    hashAlgorithm: 'whatnot',
+    integrity: 'sha1-deadbeef',
     time: 12345,
     metadata: 'yay'
   }
   const fixture = new Tacks(CacheIndex({
     'whatever': [
-      { key: 'ohnoes', digest: 'welp!' },
+      { key: 'ohnoes', integrity: 'sha1-welp!' },
       entry,
-      { key: 'nope', digest: 'bada55' }
+      { key: 'nope', integrity: 'sha1-bada55' }
     ]
   }))
   fixture.create(CACHE)

--- a/test/ls.js
+++ b/test/ls.js
@@ -18,15 +18,13 @@ test('basic listing', function (t) {
   const contents = {
     'whatever': {
       key: 'whatever',
-      digest: 'deadbeef',
-      hashAlgorithm: 'whatnot',
+      integrity: 'sha512-deadbeef',
       time: 12345,
       metadata: 'omgsometa'
     },
     'whatnot': {
       key: 'whatnot',
-      digest: 'bada55',
-      hashAlgorithm: 'whateva',
+      integrity: 'sha512-bada55',
       time: 54321,
       metadata: null
     }
@@ -34,10 +32,10 @@ test('basic listing', function (t) {
   const fixture = new Tacks(CacheIndex(contents))
   contents.whatever.path =
     contentPath(
-      CACHE, contents.whatever.digest, contents.whatever.hashAlgorithm)
+      CACHE, contents.whatever.integrity)
   contents.whatnot.path =
     contentPath(
-      CACHE, contents.whatnot.digest, contents.whatnot.hashAlgorithm)
+      CACHE, contents.whatnot.integrity)
   fixture.create(CACHE)
   return ls(CACHE).then(listing => {
     t.deepEqual(listing, contents, 'index contents correct')
@@ -57,15 +55,13 @@ test('separate keys in conflicting buckets', function (t) {
   const contents = {
     'whatever': {
       key: 'whatever',
-      digest: 'deadbeef',
-      hashAlgorithm: 'whatnot',
+      integrity: 'sha512-deadbeef',
       time: 12345,
       metadata: 'omgsometa'
     },
     'whatev': {
       key: 'whatev',
-      digest: 'bada55',
-      hashAlgorithm: 'whateva',
+      integrity: 'sha512-bada55',
       time: 54321,
       metadata: null
     }
@@ -76,10 +72,10 @@ test('separate keys in conflicting buckets', function (t) {
   }))
   contents.whatever.path =
     contentPath(
-      CACHE, contents.whatever.digest, contents.whatever.hashAlgorithm)
+      CACHE, contents.whatever.integrity)
   contents.whatev.path =
     contentPath(
-      CACHE, contents.whatev.digest, contents.whatev.hashAlgorithm)
+      CACHE, contents.whatev.integrity)
   fixture.create(CACHE)
   return ls(CACHE).then(listing => {
     t.deepEqual(listing, contents, 'index contents correct')

--- a/test/memoization.js
+++ b/test/memoization.js
@@ -7,8 +7,7 @@ const memo = require('../lib/memoization')
 const CACHE = 'mycache'
 const ENTRY = {
   key: 'foo',
-  digest: 'deadbeef',
-  hashAlgorithm: 'sha512',
+  integrity: 'sha512-deadbeef',
   time: new Date(),
   metadata: null
 }
@@ -21,7 +20,7 @@ test('memoizes entry and data by key', t => {
       entry: ENTRY,
       data: DATA
     },
-    [`digest:${CACHE}:${ENTRY.hashAlgorithm}:${ENTRY.digest}`]: DATA
+    [`digest:${CACHE}:${ENTRY.integrity}`]: DATA
   }, 'cache has both key and digest entries')
   t.done()
 })
@@ -44,7 +43,7 @@ test('can fetch data by key', t => {
 test('can fetch data by digest', t => {
   memo.put(CACHE, ENTRY, DATA)
   t.deepEqual(
-    memo.get.byDigest(CACHE, ENTRY.digest, ENTRY.hashAlgorithm),
+    memo.get.byDigest(CACHE, ENTRY.integrity),
     DATA,
     'got raw data by digest, without an entry'
   )
@@ -61,7 +60,7 @@ test('can clear out the memoization cache', t => {
     'entry not there anymore'
   )
   t.deepEqual(
-    memo.get.byDigest(ENTRY.digest),
+    memo.get.byDigest(ENTRY.integrity),
     null,
     'digest-based data not there anymore'
   )

--- a/test/rm.js
+++ b/test/rm.js
@@ -3,20 +3,19 @@
 const Buffer = require('safe-buffer').Buffer
 const BB = require('bluebird')
 
-const crypto = require('crypto')
 const fs = BB.promisifyAll(require('fs'))
 const index = require('../lib/entry-index')
 const path = require('path')
 const Tacks = require('tacks')
 const test = require('tap').test
 const testDir = require('./util/test-dir')(__filename)
+const ssri = require('ssri')
 
 const CacheContent = require('./util/cache-content')
 const CACHE = path.join(testDir, 'cache')
 const CONTENT = Buffer.from('foobarbaz')
 const KEY = 'my-test-key'
-const ALGO = 'sha512'
-const DIGEST = crypto.createHash(ALGO).update(CONTENT).digest('hex')
+const INTEGRITY = ssri.fromData(CONTENT)
 const METADATA = { foo: 'bar' }
 const contentPath = require('../lib/content/path')
 
@@ -26,12 +25,11 @@ const rm = require('..').rm
 
 test('rm.entry removes entries, not content', t => {
   const fixture = new Tacks(CacheContent({
-    [DIGEST]: CONTENT
-  }, ALGO))
+    [INTEGRITY]: CONTENT
+  }))
   fixture.create(CACHE)
-  return index.insert(CACHE, KEY, DIGEST, {
-    metadata: METADATA,
-    hashAlgorithm: ALGO
+  return index.insert(CACHE, KEY, INTEGRITY, {
+    metadata: METADATA
   }).then(() => {
     t.equal(rm, rm.entry, 'rm is an alias for rm.entry')
     return rm.entry(CACHE, KEY)
@@ -42,7 +40,7 @@ test('rm.entry removes entries, not content', t => {
   }).catch({code: 'ENOENT'}, err => {
     t.match(err.message, /not found/, 'entry no longer accessible')
   }).then(() => {
-    return fs.readFileAsync(contentPath(CACHE, DIGEST, ALGO))
+    return fs.readFileAsync(contentPath(CACHE, INTEGRITY))
   }).then(data => {
     t.deepEqual(data, CONTENT, 'content remains in cache')
   })
@@ -50,14 +48,13 @@ test('rm.entry removes entries, not content', t => {
 
 test('rm.content removes content, not entries', t => {
   const fixture = new Tacks(CacheContent({
-    [DIGEST]: CONTENT
-  }, ALGO))
+    [INTEGRITY]: CONTENT
+  }))
   fixture.create(CACHE)
-  return index.insert(CACHE, KEY, DIGEST, {
-    metadata: METADATA,
-    hashAlgorithm: ALGO
+  return index.insert(CACHE, KEY, INTEGRITY, {
+    metadata: METADATA
   }).then(() => {
-    return rm.content(CACHE, DIGEST)
+    return rm.content(CACHE, INTEGRITY)
   }).then(() => {
     return get(CACHE, KEY)
   }).then(res => {
@@ -65,7 +62,7 @@ test('rm.content removes content, not entries', t => {
   }).catch({code: 'ENOENT'}, err => {
     t.match(err.message, /no such file/, 'entry no longer accessible')
   }).then(() => {
-    return fs.readFileAsync(contentPath(CACHE, DIGEST, ALGO))
+    return fs.readFileAsync(contentPath(CACHE, INTEGRITY))
   }).then(() => {
     throw new Error('unexpected success')
   }).catch({code: 'ENOENT'}, err => {
@@ -75,12 +72,11 @@ test('rm.content removes content, not entries', t => {
 
 test('rm.all deletes content and index dirs', t => {
   const fixture = new Tacks(CacheContent({
-    [DIGEST]: CONTENT
-  }, ALGO))
+    [INTEGRITY]: CONTENT
+  }))
   fixture.create(CACHE)
-  return index.insert(CACHE, KEY, DIGEST, {
-    metadata: METADATA,
-    hashAlgorithm: ALGO
+  return index.insert(CACHE, KEY, INTEGRITY, {
+    metadata: METADATA
   }).then(() => {
     return fs.mkdirAsync(path.join(CACHE, 'tmp'))
   }).then(() => {

--- a/test/util/cache-content.js
+++ b/test/util/cache-content.js
@@ -8,11 +8,10 @@ const Dir = Tacks.Dir
 const File = Tacks.File
 
 module.exports = CacheContent
-function CacheContent (entries, hashAlgorithm) {
-  hashAlgorithm = hashAlgorithm || 'sha512'
+function CacheContent (entries) {
   var tree = Dir({})
   Object.keys(entries).forEach(function (k) {
-    const cpath = contentPath('', k, hashAlgorithm)
+    const cpath = contentPath('', k)
     const content = entries[k]
     const parts = cpath.split(path.sep)
     insertContent(tree, parts, content)


### PR DESCRIPTION
This PR changes all digest-related API bits. Now, instead of having to always pair up a `digest` with a `hashAlgorithm`, a single string can be used. This is based on the [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) spec, which is what browsers use for this sort of checking.

This is a major breaking change because it changes the way all the `digest` options are used. It'll also bump the index version again.

This PR will not change content storage format: that should keep using the `hex` version of the digest, because the current filesystem structure is much more friendly across platforms. base64 encodings have case-variance (which messed with OSX and Windows), as well as some characters like `/` and `+` that will inevitably confuse _someone's_ tool/script at some point.

Note that `hashAlgorithm` will still be an option for `put/put.stream`.

The biggest reason for doing this is realizing how unergonomic it was to always have to pass in `hashAlgorithm` whenever get/put was being used with a digest -- in some cases requiring modification of `opts`. It has also been a source of bugs both in pacote and cacache itself. I'd much rather simplify this by keeping these two bits together.