### PR TITLE
docs: add get.hasContent method and opts.algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ can just as easily be used on its own
     * [`get`](#get-data)
     * [`get.stream`](#get-stream)
     * [`get.info`](#get-info)
+    * [`get.hasContent`](#get-hasContent)
   * Writing
     * [`put`](#put-data)
     * [`put.stream`](#put-stream)
@@ -292,6 +293,39 @@ cacache.get.info(cachePath, 'my-thing').then(console.log)
     description: 'this was once a package but now it is my-thing'
   }
 }
+```
+
+#### <a name="get-hasContent"></a> `> cacache.get.hasContent(cache, integrity) -> Promise`
+
+Looks up a [Subresource Integrity hash](#integrity) in the cache. If content 
+exists for this `integrity`, it will return the specific single integrity hash
+that was found. If no content exists for this integrity, it will return `false`.
+
+##### Fields
+
+* `source` - The [Subresource Integrity hash](#integrity) that was provided as an
+argument and subsequently found in the cache.
+* `algorithm` - The algorithm used in the hash.
+* `digest` - The digest portion of the hash.
+* `options`
+
+##### Example
+
+```javascript
+cacache.get.hasContent(cachePath, 'sha256-MUSTVERIFY+ALL/THINGS==').then(console.log)
+
+// Output
+{
+  source: 'sha256-MUSTVERIFY+ALL/THINGS==',
+  algorithm: 'sha256',
+  digest: 'MUSTVERIFY+ALL/THINGS==',
+  options: []
+}
+
+cacache.get.hasContent(cachePath, 'sha521-NOT+IN/CACHE==').then(console.log)
+
+// Output
+false
 ```
 
 #### <a name="put-data"></a> `> cacache.put(cache, key, data, [opts]) -> Promise`

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ false
 #### <a name="put-data"></a> `> cacache.put(cache, key, data, [opts]) -> Promise`
 
 Inserts data passed to it into the cache. The returned Promise resolves with a
-digest (generated according to [`opts.hashAlgorithm`](#hashalgorithm)) after the
+digest (generated according to [`opts.algorithms`](#optsalgorithms)) after the
 cache entry has been successfully written.
 
 ##### Example
@@ -385,19 +385,20 @@ If present, the pre-calculated digest for the inserted content. If this option
 if provided and does not match the post-insertion digest, insertion will fail
 with an `EINTEGRITY` error.
 
-`hashAlgorithm` has no effect if this option is present.
+`algorithms` has no effect if this option is present.
 
-##### `opts.hashAlgorithm`
+##### `opts.algorithms`
 
-Default: 'sha512'
+Default: ['sha512']
 
-Hashing algorithm to use when calculating the [subresource integrity
+Hashing algorithms to use when calculating the [subresource integrity
 digest](#integrity)
 for inserted data. Can use any algorithm listed in `crypto.getHashes()` or
 `'omakase'`/`'お任せします'` to pick a random hash algorithm on each insertion. You
 may also use any anagram of `'modnar'` to use this feature.
 
-Has no effect if `opts.integrity` is present.
+Currently only supports one algorithm at a time (i.e., an array length of 
+exactly `1`). Has no effect if `opts.integrity` is present.
 
 ##### `opts.uid`/`opts.gid`
 


### PR DESCRIPTION
Hello! :wave:

I implemented `cacache` in my project yesterday and noticed these two things missing from the docs. I took a crack at adding them and emulating the existing writing style. Let me know if there's anything I need to tweak or any other things you know of that still need docs. I'd be happy to help out.

Thanks for writing this package! It's exactly what I was looking for. 👌 