### PR TITLE
make verified content completely read-only

### DIFF
--- a/lib/util/move-file.js
+++ b/lib/util/move-file.js
@@ -2,6 +2,8 @@
 
 const fs = require('graceful-fs')
 const BB = require('bluebird')
+const chmod = BB.promisify(fs.chmod)
+const unlink = BB.promisify(fs.unlink)
 let move
 let pinflight
 
@@ -27,19 +29,11 @@ function moveFile (src, dest) {
           return cb(err)
         }
       }
-      if (process.platform !== 'win32') {
-        // content should never change for any reason, so make it read-only
-        fs.chmod(dest, '0444' /* -r--r--r-- */, err => {
-          if (err) {
-            // pretty much any error at this point is bad
-            return cb(err)
-          }
-          return fs.unlink(src, cb)
-        })
-      } else {
-        return fs.unlink(src, cb)
-      }
+      return cb()
     })
+  }).then(() => {
+    // content should never change for any reason, so make it read-only
+    return BB.join(unlink(src), process.platform !== 'win32' && chmod(dest, '0444'))
   }).catch(err => {
     if (process.platform !== 'win32') {
       throw err

--- a/lib/util/move-file.js
+++ b/lib/util/move-file.js
@@ -27,7 +27,14 @@ function moveFile (src, dest) {
           return cb(err)
         }
       }
-      return fs.unlink(src, cb)
+      // content should never change for any reason, so make it read-only
+      fs.chmod(dest, '0444' /* -r--r--r-- */, err => {
+        if (err) {
+          // pretty much any error at this point is bad
+          return cb(err)
+        }
+        return fs.unlink(src, cb)
+      })
     })
   }).catch(err => {
     if (process.platform !== 'win32') {

--- a/lib/util/move-file.js
+++ b/lib/util/move-file.js
@@ -27,14 +27,18 @@ function moveFile (src, dest) {
           return cb(err)
         }
       }
-      // content should never change for any reason, so make it read-only
-      fs.chmod(dest, '0444' /* -r--r--r-- */, err => {
-        if (err) {
-          // pretty much any error at this point is bad
-          return cb(err)
-        }
+      if (process.platform !== 'win32') {
+        // content should never change for any reason, so make it read-only
+        fs.chmod(dest, '0444' /* -r--r--r-- */, err => {
+          if (err) {
+            // pretty much any error at this point is bad
+            return cb(err)
+          }
+          return fs.unlink(src, cb)
+        })
+      } else {
         return fs.unlink(src, cb)
-      })
+      }
     })
   }).catch(err => {
     if (process.platform !== 'win32') {


### PR DESCRIPTION
The only non-corrupting modification to content stored in cacache is to
delete it, and that requires write permission on the containing
directory rather than on the file itself. Since no valid operations
require write permissions on the content files, mark them as read-only
so that the rest of the OS knows these files aren't meant to be written
to.

Resolves #95