### PR TITLE
Revert "fix(content): make verified content completely read-only (#96)"

### DIFF
--- a/lib/util/move-file.js
+++ b/lib/util/move-file.js
@@ -2,8 +2,6 @@
 
 const fs = require('graceful-fs')
 const BB = require('bluebird')
-const chmod = BB.promisify(fs.chmod)
-const unlink = BB.promisify(fs.unlink)
 let move
 let pinflight
 
@@ -29,11 +27,8 @@ function moveFile (src, dest) {
           return cb(err)
         }
       }
-      return cb()
+      return fs.unlink(src, cb)
     })
-  }).then(() => {
-    // content should never change for any reason, so make it read-only
-    return BB.join(unlink(src), process.platform !== 'win32' && chmod(dest, '0444'))
   }).catch(err => {
     if (process.platform !== 'win32') {
       throw err


### PR DESCRIPTION
In our Jenkins set up we change the npm cache directory to be within the build workspace and using the [Copy to Slave plugin](https://wiki.jenkins.io/display/JENKINS/Copy+To+Slave+Plugin) copy it between the master node and the build nodes.  This speeds up builds by not having to download dependencies for each build when the workspace is clean and is similar to [Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) on Travis.  The build process is:

1. Clone repo
2. Copy .cache/ directory from master node to build node
3. `npm install` + other build steps, potentially updating the .cache/ directory
4. Copy .cache/ back to the master node

This has worked well until we updated to node 8 with npm 5 where we were seeing permission denied errors due to some files being read only.  Adding `find .cache/ -perm 444 -exec chmod 644 '{}' \;` to the end of the build works around the problem but it's a hack and one which I'd rather not have to add to hundreds of jobs.

I'd like to propose that the change making some files read only be reverted as it breaks existing workflows with other tools.
