### PR TITLE
Fix moveFile for Android

### DIFF
--- a/lib/util/move-file.js
+++ b/lib/util/move-file.js
@@ -35,21 +35,17 @@ function moveFile (src, dest) {
     // content should never change for any reason, so make it read-only
     return BB.join(unlink(src), process.platform !== 'win32' && chmod(dest, '0444'))
   }).catch(err => {
-    if (process.platform !== 'win32' && process.platform !== 'android') {
-      throw err
-    } else {
-      if (!pinflight) { pinflight = require('promise-inflight') }
-      return pinflight('cacache-move-file:' + dest, () => {
-        return BB.promisify(fs.stat)(dest).catch(err => {
-          if (err.code !== 'ENOENT') {
-            // Something else is wrong here. Bail bail bail
-            throw err
-          }
-          // file doesn't already exist! let's try a rename -> copy fallback
-          if (!move) { move = require('move-concurrently') }
-          return move(src, dest, { BB, fs })
-        })
+    if (!pinflight) { pinflight = require('promise-inflight') }
+    return pinflight('cacache-move-file:' + dest, () => {
+      return BB.promisify(fs.stat)(dest).catch(err => {
+        if (err.code !== 'ENOENT') {
+          // Something else is wrong here. Bail bail bail
+          throw err
+        }
+        // file doesn't already exist! let's try a rename -> copy fallback
+        if (!move) { move = require('move-concurrently') }
+        return move(src, dest, { BB, fs })
       })
-    }
+    })
   })
 }

--- a/lib/util/move-file.js
+++ b/lib/util/move-file.js
@@ -35,7 +35,7 @@ function moveFile (src, dest) {
     // content should never change for any reason, so make it read-only
     return BB.join(unlink(src), process.platform !== 'win32' && chmod(dest, '0444'))
   }).catch(err => {
-    if (process.platform !== 'win32') {
+    if (process.platform !== 'win32' && process.platform !== 'android') {
       throw err
     } else {
       if (!pinflight) { pinflight = require('promise-inflight') }

--- a/lib/util/move-file.js
+++ b/lib/util/move-file.js
@@ -41,7 +41,7 @@ function moveFile (src, dest) {
       if (!pinflight) { pinflight = require('promise-inflight') }
       return pinflight('cacache-move-file:' + dest, () => {
         return BB.promisify(fs.stat)(dest).catch(err => {
-          if (err !== 'ENOENT') {
+          if (err.code !== 'ENOENT') {
             // Something else is wrong here. Bail bail bail
             throw err
           }


### PR DESCRIPTION
Since Android 6.0 calling creating a hardlink is [forbidden by design](https://stackoverflow.com/questions/32365690/is-android-m-not-allowing-hard-links). Every call to `link()` returns `EACCESS`. Therefore, projects such as [Termux](https://termux.com) are having problem with using npm to install packages on Android. This is reported in termux/termux-packages#1192 and npm/npm#17480. After manually patching cacache in npm with this change I was able to succesfully install packages from npm on Android.

This pull requests fixes the issue, by making cacache move files using `move-concurrently` if `link()` fails also on Android, just as it was  intended to work on `win32`.

As I was testing it, I've noticed the path where `link()` failed on `win32` was also not functioning as intended, throwing `ENOENT` every time. That is also addressed in this PR.