### PR TITLE
feat(license): relicense to ISC

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,16 @@
-To the extent possible under law, maintainers for this project have waived all copyright and related or neighboring rights to this project.
+ISC License
 
-For more information on this waiver, see: https://creativecommons.org/publicdomain/zero/1.0/
+Copyright (c) npm, Inc.
+
+Permission to use, copy, modify, and/or distribute this software for
+any purpose with or without fee is hereby granted, provided that the
+above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE COPYRIGHT HOLDER DISCLAIMS
+ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
+USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
       "twitter": "ReBeccaOrg"
     }
   ],
-  "license": "CC0-1.0",
+  "license": "ISC",
   "dependencies": {
     "bluebird": "^3.5.0",
     "chownr": "^1.0.1",


### PR DESCRIPTION
Fixes: #109

BREAKING CHANGE: the license has been changed from CC0-1.0 to ISC.

Hey y'all: I'm gonna need consent from all contributors so far to do this. I'm using the ISC license here for the sake of consistency with npm, since that's our default license, and also the one the main project uses: It is pretty much the same as MIT, and unlike CC0-1.0, is actually OSI approved. This means teams constrained by lawyers and policy will be able to use cacache without having to worry about licensing issues. This came up recently in https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/120.

So, I'm gonna ping all the folks I need a 👍 from. **PLEASE PUT A 👍 IN AN ACTUAL REPLY**

* [x] @zkat
* [x] @iarna 
* [x] @chrisdickinson 
* [x] @varjmes 
* [x] @rmg 
* [x] @cilice 
* [x] @Lange 
* [x] @mystfox 

The sooner y'all reply, the better. I'd like to get this done as quickly as possible. Thanks!