### PR TITLE
fix(verify): size param no longer lost in a verify

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -197,7 +197,8 @@ function rebuildBucket (cache, bucket, stats, opts) {
         return index.insert(cache, entry.key, entry.integrity, {
           uid: opts.uid,
           gid: opts.gid,
-          metadata: entry.metadata
+          metadata: entry.metadata,
+          size: entry.size
         }).then(() => { stats.totalEntries++ })
       }).catch({code: 'ENOENT'}, () => {
         stats.rejectedEntries++


### PR DESCRIPTION
Fixes a bug were after the cache was verified the 'size' parameter was
lost from the index of the entry.

Fixes: #130

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
