### PR TITLE
Add ssri config 'error' option

### DIFF
--- a/put.js
+++ b/put.js
@@ -20,6 +20,7 @@ const PutOpts = figgyPudding({
   gid: {},
   single: {},
   sep: {},
+  error: {},
   strict: {}
 })
 

--- a/test/put.js
+++ b/test/put.js
@@ -102,6 +102,16 @@ test('optionally memoizes data on stream insertion', t => {
   })
 })
 
+test('errors if integrity errors', t => {
+  return BB.join(
+    put(CACHE, KEY, CONTENT, {
+      integrity: 'sha1-BaDDigEST'
+    }).catch(err => {
+      t.equal(err.code, 'EINTEGRITY', 'got error from bad integrity')
+    })
+  )
+})
+
 test('signals error if error writing to cache', t => {
   return BB.join(
     put(CACHE, KEY, CONTENT, {


### PR DESCRIPTION
Add another ssri config option (which is only used when the integrity is wrong) and a test case to ensure the right error is thrown when the integrity is wrong (and not, say, an ssri config option error).

See https://npm.community/t/npm-install-tgz-invalid-config-key-requested/2395.
See https://github.com/zkat/cacache/commit/10d5d9a8c2d42217e12eb16619ba9cc2f5751364