### PR TITLE
Fix docs for `path` property in get.info

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -287,7 +287,7 @@ entrada si existe.
 
 * `key` - Clave de la entrada. Igual al argumento `clave`.
 * `integrity` - [hacheo de Subresource Integrity](#integrity) del contenido al que se refiere esta entrada.
-* `path` - Dirección del fichero de datos almacenados, unido con argumento `cache`.
+* `path` - Dirección del fichero de datos almacenados, unida al argumento `cache`.
 * `time` - Hora de creación de la entrada
 * `metadata` - Metadatos asignados a esta entrada por el usuario
 

--- a/README.es.md
+++ b/README.es.md
@@ -287,7 +287,7 @@ entrada si existe.
 
 * `key` - Clave de la entrada. Igual al argumento `clave`.
 * `integrity` - [hacheo de Subresource Integrity](#integrity) del contenido al que se refiere esta entrada.
-* `path` - Dirección del fichero de datos almacenados, relativa al argumento `cache`.
+* `path` - Dirección del fichero de datos almacenados, unido con argumento `cache`.
 * `time` - Hora de creación de la entrada
 * `metadata` - Metadatos asignados a esta entrada por el usuario
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ one exists.
 
 * `key` - Key the entry was looked up under. Matches the `key` argument.
 * `integrity` - [Subresource Integrity hash](#integrity) for the content this entry refers to.
-* `path` - Filesystem path relative to `cache` argument where content is stored.
+* `path` - Filesystem path where content is stored, joined with `cache` argument.
 * `time` - Timestamp the entry was first added on.
 * `metadata` - User-assigned metadata associated with the entry/content.
 


### PR DESCRIPTION
Fixes #165. I don't speak Spanish but I made an attempt at updating
README.es.md too, based on the "joined with `cachePath`" comments I saw
in the `ls` docs; hopefully what I've got here makes sense :)

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
